### PR TITLE
COMMONSRDF-52 set distinct Bundle-SymbolicName values

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -33,6 +33,10 @@
     <name>Commons RDF API</name>
     <description>Commons Java API for RDF 1.1</description>
 
+    <properties>
+      <commons.osgi.symbolicName>org.apache.commons.rdf.api</commons.osgi.symbolicName>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -33,6 +33,10 @@
 	<name>Commons RDF impl: Jena</name>
 	<description>Apache Jena implementation of Commons RDF API</description>
 
+  <properties>
+    <commons.osgi.symbolicName>org.apache.commons.rdf.jena</commons.osgi.symbolicName>
+  </properties>
+
     <distributionManagement>
       <site>
         <id>commonsrdf-api-site</id>

--- a/jsonld-java/pom.xml
+++ b/jsonld-java/pom.xml
@@ -33,6 +33,10 @@
     <name>Commons RDF impl: JSON-LD Java</name>
     <description>Parser integration of JSON-LD Java</description>
 
+    <properties>
+      <commons.osgi.symbolicName>org.apache.commons.rdf.jsonldjava</commons.osgi.symbolicName>
+    </properties>
+
     <distributionManagement>
       <site>
         <id>commonsrdf-api-site</id>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -33,6 +33,10 @@
 	<name>Commons RDF impl: RDF4j</name>
 	<description>Eclipse RDF4j implementation of Commons RDF API</description>
 
+  <properties>
+    <commons.osgi.symbolicName>org.apache.commons.rdf.rdf4j</commons.osgi.symbolicName>
+  </properties>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/simple/pom.xml
+++ b/simple/pom.xml
@@ -33,6 +33,10 @@
     <name>Commons RDF impl: Simple</name>
     <description>Simple (if not naive) implementation of Commons RDF API</description>
 
+    <properties>
+      <commons.osgi.symbolicName>org.apache.commons.rdf.simple</commons.osgi.symbolicName>
+    </properties>
+
     <distributionManagement>
       <site>
         <id>commonsrdf-api-site</id>


### PR DESCRIPTION
In the 0.3.0-incubating release, all of the commons-rdf components have the same `Symbolic-BundleName`, namely: `org.apache.commons.rdf`. This makes it impossible to install multiple bundles in an OSGi container (e.g. Karaf), as every bundle must have a distinct Symbolic-BundleName/Version combination.

The commons-parent pom configuration provides a mechanism for setting the value of `Symbolic-BundleName` in the bundle manifest, as shown in this PR.