### PR TITLE
[COMMONSRDF-53] Add ServiceLoader support in OSGi

### DIFF
--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -33,10 +33,6 @@
 	<name>Commons RDF impl: Jena</name>
 	<description>Apache Jena implementation of Commons RDF API</description>
 
-  <properties>
-    <commons.osgi.symbolicName>org.apache.commons.rdf.jena</commons.osgi.symbolicName>
-  </properties>
-
     <distributionManagement>
       <site>
         <id>commonsrdf-api-site</id>
@@ -97,4 +93,19 @@
 		</dependency>
 	</dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.apache.commons.rdf.jena</Bundle-SymbolicName>
+            <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+            <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.commons.rdf.api.RDF</Provide-Capability>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/jsonld-java/pom.xml
+++ b/jsonld-java/pom.xml
@@ -33,10 +33,6 @@
     <name>Commons RDF impl: JSON-LD Java</name>
     <description>Parser integration of JSON-LD Java</description>
 
-    <properties>
-      <commons.osgi.symbolicName>org.apache.commons.rdf.jsonldjava</commons.osgi.symbolicName>
-    </properties>
-
     <distributionManagement>
       <site>
         <id>commonsrdf-api-site</id>
@@ -70,4 +66,19 @@
         
     </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.apache.commons.rdf.jsonldjava</Bundle-SymbolicName>
+            <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+            <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.commons.rdf.api.RDF</Provide-Capability>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -33,10 +33,6 @@
 	<name>Commons RDF impl: RDF4j</name>
 	<description>Eclipse RDF4j implementation of Commons RDF API</description>
 
-  <properties>
-    <commons.osgi.symbolicName>org.apache.commons.rdf.rdf4j</commons.osgi.symbolicName>
-  </properties>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -50,6 +46,9 @@
 
 						<Export-Package>org.apache.commons.rdf.rdf4j</Export-Package>
 						<Private-Package>org.apache.commons.rdf.rdf4j.impl</Private-Package>
+						<Bundle-SymbolicName>org.apache.commons.rdf.rdf4j</Bundle-SymbolicName>
+						<Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+						<Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.commons.rdf.api.RDF</Provide-Capability>
 					</instructions>
 				</configuration>
 			</plugin>

--- a/simple/pom.xml
+++ b/simple/pom.xml
@@ -33,10 +33,6 @@
     <name>Commons RDF impl: Simple</name>
     <description>Simple (if not naive) implementation of Commons RDF API</description>
 
-    <properties>
-      <commons.osgi.symbolicName>org.apache.commons.rdf.simple</commons.osgi.symbolicName>
-    </properties>
-
     <distributionManagement>
       <site>
         <id>commonsrdf-api-site</id>
@@ -59,4 +55,19 @@
         </dependency>
     </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.apache.commons.rdf.simple</Bundle-SymbolicName>
+            <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+            <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.commons.rdf.api.RDF</Provide-Capability>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Resolves: COMMONSRDF-53

This adds bundle metadata for the commons-rdf modules to make it easier to work with the Java `ServiceLoader` in an OSGi context. This consolidates the OSGi configuration, removing the `commons.osgi.symbolicName` definition and putting all OSGi-related configuration directly in the `maven-bundle-plugin` (now that the plugin must be explicitly configured in maven).