### PR TITLE
COMMONSRDF-51 language tags compared lower case

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/Literal.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Literal.java
@@ -18,6 +18,7 @@
 package org.apache.commons.rdf.api;
 
 import java.io.Serializable;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -72,7 +73,13 @@ public interface Literal extends RDFTerm {
      * <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
      * >http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</a>, this method
      * must return {@link Optional#empty()}.
-     *
+     * <p>
+     * The value space of language tags is always in lower case; although 
+     * RDF implementations MAY convert all language tags to lower case,
+     * safe comparisons of language tags should be done using
+     * {@link String#toLowerCase(Locale)} with the locale
+     * {@link Locale#ROOT}. 
+     * <p>
      * Implementation note: If your application requires {@link Serializable}
      * objects, it is best not to store an {@link Optional} in a field. It is
      * recommended to use {@link Optional#ofNullable(Object)} to create the
@@ -80,8 +87,8 @@ public interface Literal extends RDFTerm {
      *
      * @return The {@link Optional} language tag for this literal. If
      *         {@link Optional#isPresent()} returns true, the value returned by
-     *         {@link Optional#get()} must be a non-empty string conforming to
-     *         BCP47.
+     *         {@link Optional#get()} must be a non-empty language tag string
+     *         conforming to BCP47.
      * @see <a href=
      *      "http://www.w3.org/TR/rdf11-concepts/#dfn-language-tag">RDF-1.1
      *      Literal language tag</a>
@@ -89,14 +96,20 @@ public interface Literal extends RDFTerm {
     Optional<String> getLanguageTag();
 
     /**
-     * Check it this Literal is equal to another Literal. <blockquote>
+     * Check it this Literal is equal to another Literal. 
+     * <blockquote>
      * <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal-term">Literal
-     * term equality</a>: Two literals are term-equal (the same RDF literal) if
+     * term equality</a>: 
+     * Two literals are term-equal (the same RDF literal) if
      * and only if the two lexical forms, the two datatype IRIs, and the two
      * language tags (if any) compare equal, character by character. Thus, two
      * literals can have the same value without being the same RDF term.
      * </blockquote>
-     *
+     * As the value space for language tags is lower-space, if they are present,
+     * they MUST be compared character by character
+     * using the equivalent of {@link String#toLowerCase(java.util.Locale)} with
+     * the locale {@link Locale#ROOT}.
+     * <p>
      * Implementations MUST also override {@link #hashCode()} so that two equal
      * Literals produce the same hash code.
      *
@@ -114,7 +127,7 @@ public interface Literal extends RDFTerm {
      * The returned hash code MUST be equal to the result of
      * {@link Objects#hash(Object...)} with the arguments
      * {@link #getLexicalForm()}, {@link #getDatatype()},
-     * {@link #getLanguageTag()}.
+     * {@link #getLanguageTag()}<code>.map(s-&gt;s.toLowerString(Locale.ROOT))</code>.
      * <p>
      * This method MUST be implemented in conjunction with
      * {@link #equals(Object)} so that two equal Literals produce the same hash

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractDatasetTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractDatasetTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -542,7 +543,145 @@ public abstract class AbstractDatasetTest {
     }
     
 
+    @Test
+    public void containsLanguageTagsCaseInsensitive() {
+        // COMMONSRDF-51: Ensure we can add/contains/remove with any casing
+        // of literal language tag
+        final Literal lower = factory.createLiteral("Hello", "en-gb");
+        final Literal upper = factory.createLiteral("Hello", "EN-GB");
+        final Literal mixed = factory.createLiteral("Hello", "en-GB");
+
+        final IRI example1 = factory.createIRI("http://example.com/s1");
+        final IRI greeting = factory.createIRI("http://example.com/greeting");
+
+        
+        dataset.add(null, example1, greeting, upper);
+        
+        // any kind of Triple should match
+        assertTrue(dataset.contains(factory.createQuad(null, example1, greeting, upper)));
+        assertTrue(dataset.contains(factory.createQuad(null, example1, greeting, lower)));
+        assertTrue(dataset.contains(factory.createQuad(null, example1, greeting, mixed)));
+
+        // or as patterns
+        assertTrue(dataset.contains(null, null, null, upper));
+        assertTrue(dataset.contains(null, null, null, lower));
+        assertTrue(dataset.contains(null, null, null, mixed));
+    }
+
+    @Test
+    public void containsLanguageTagsCaseInsensitiveTurkish() {
+        // COMMONSRDF-51: Special test for Turkish issue where
+        // "i".toLowerCase() != "i"
+        // See also:
+        // https://garygregory.wordpress.com/2015/11/03/java-lowercase-conversion-turkey/
+
+        // This is similar to the test in AbstractRDFTest, but on a graph
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.ROOT);
+            final Literal lowerROOT = factory.createLiteral("moi", "fi");
+            final Literal upperROOT = factory.createLiteral("moi", "FI");
+            final Literal mixedROOT = factory.createLiteral("moi", "fI");
+            final IRI exampleROOT = factory.createIRI("http://example.com/s1");
+            final IRI greeting = factory.createIRI("http://example.com/greeting");
+            dataset.add(null, exampleROOT, greeting, mixedROOT);
+
+            Locale turkish = Locale.forLanguageTag("TR");
+            Locale.setDefault(turkish);
+            // If the below assertion fails, then the Turkish
+            // locale no longer have this peculiarity that
+            // we want to test.
+            Assume.assumeFalse("FI".toLowerCase().equals("fi"));
+
+            // Below is pretty much the same as in
+            // containsLanguageTagsCaseInsensitive()
+            final Literal lower = factory.createLiteral("moi", "fi");
+            final Literal upper = factory.createLiteral("moi", "FI");
+            final Literal mixed = factory.createLiteral("moi", "fI");
+
+            final IRI exampleTR = factory.createIRI("http://example.com/s2");
+            dataset.add(null, exampleTR, greeting, upper);
+            assertTrue(dataset.contains(factory.createQuad(null, exampleTR, greeting, upper)));
+            assertTrue(dataset.contains(factory.createQuad(null, exampleTR, greeting, upperROOT)));
+            assertTrue(dataset.contains(factory.createQuad(null, exampleTR, greeting, lower)));
+            assertTrue(dataset.contains(factory.createQuad(null, exampleTR, greeting, lowerROOT)));
+            assertTrue(dataset.contains(factory.createQuad(null, exampleTR, greeting, mixed)));
+            assertTrue(dataset.contains(factory.createQuad(null, exampleTR, greeting, mixedROOT)));
+            assertTrue(dataset.contains(null, exampleTR, null, upper));
+            assertTrue(dataset.contains(null, exampleTR, null, upperROOT));
+            assertTrue(dataset.contains(null, exampleTR, null, lower));
+            assertTrue(dataset.contains(null, exampleTR, null, lowerROOT));
+            assertTrue(dataset.contains(null, exampleTR, null, mixed));
+            assertTrue(dataset.contains(null, exampleTR, null, mixedROOT));
+
+            // What about the triple we added while in ROOT locale?
+            assertTrue(dataset.contains(factory.createQuad(null, exampleROOT, greeting, upper)));
+            assertTrue(dataset.contains(factory.createQuad(null, exampleROOT, greeting, lower)));
+            assertTrue(dataset.contains(factory.createQuad(null, exampleROOT, greeting, mixed)));
+            assertTrue(dataset.contains(null, exampleROOT, null, upper));
+            assertTrue(dataset.contains(null, exampleROOT, null, lower));
+            assertTrue(dataset.contains(null, exampleROOT, null, mixed));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
     
+
+    @Test
+    public void removeLanguageTagsCaseInsensitive() {
+        // COMMONSRDF-51: Ensure we can remove with any casing
+        // of literal language tag
+        final Literal lower = factory.createLiteral("Hello", "en-gb");
+        final Literal upper = factory.createLiteral("Hello", "EN-GB");
+        final Literal mixed = factory.createLiteral("Hello", "en-GB");
+
+        final IRI example1 = factory.createIRI("http://example.com/s1");
+        final IRI greeting = factory.createIRI("http://example.com/greeting");
+
+        dataset.add(null, example1, greeting, upper);
+
+        // Remove should also honour any case
+        dataset.remove(null, example1, null, mixed);
+        assertFalse(dataset.contains(null, null, greeting, null));
+        
+        dataset.add(null, example1, greeting, lower);
+        dataset.remove(null, example1, null, upper);
+
+        // Check with Triple
+        dataset.add(factory.createQuad(null, example1, greeting, mixed));
+        dataset.remove(factory.createQuad(null, example1, greeting, upper));
+        assertFalse(dataset.contains(null, null, greeting, null));
+    }
+
+    private static Optional<? extends Quad> closableFindAny(Stream<? extends Quad> stream) {
+        try (Stream<? extends Quad> s = stream) {
+            return s.findAny();
+        }
+    }
+    
+    @Test
+    public void streamLanguageTagsCaseInsensitive() {
+        // COMMONSRDF-51: Ensure we can add/contains/remove with any casing
+        // of literal language tag
+        final Literal lower = factory.createLiteral("Hello", "en-gb");
+        final Literal upper = factory.createLiteral("Hello", "EN-GB");
+        final Literal mixed = factory.createLiteral("Hello", "en-GB");
+
+        final IRI example1 = factory.createIRI("http://example.com/s1");
+        final IRI greeting = factory.createIRI("http://example.com/greeting");
+
+        dataset.add(null, example1, greeting, upper);
+
+        // or as patterns
+        assertTrue(closableFindAny(dataset.stream(null, null, null, upper)).isPresent());
+        assertTrue(closableFindAny(dataset.stream(null, null, null, lower)).isPresent());
+        assertTrue(closableFindAny(dataset.stream(null, null, null, mixed)).isPresent());
+        
+        // Check the quad returned equal a new quad
+        Quad q = closableFindAny(dataset.stream(null, null, null, lower)).get();
+        assertEquals(q, factory.createQuad(null, example1, greeting, mixed));
+    }
+
     /**
      * An attempt to use the Java 8 streams to look up a more complicated query.
      * <p>

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,7 +47,7 @@ import org.junit.Test;
  * <p>
  * This test uses try-with-resources blocks for calls to {@link Graph#stream()}
  * and {@link Graph#iterate()}.
- * 
+ *
  * @see Graph
  * @see RDF
  */
@@ -68,10 +69,10 @@ public abstract class AbstractGraphTest {
     protected Triple bobNameTriple;
 
     /**
-     * 
+     *
      * This method must be overridden by the implementing test to provide a
      * factory for the test to create {@link Graph}, {@link IRI} etc.
-     * 
+     *
      * @return {@link RDF} instance to be tested.
      */
     protected abstract RDF createFactory();
@@ -385,6 +386,100 @@ public abstract class AbstractGraphTest {
         }
     }
 
+    @Test
+    public void containsLanguageTagsCaseInsensitive() {
+        // COMMONSRDF-51: Ensure we can add/contains/remove with any casing
+        // of literal language tag
+        final Literal lower = factory.createLiteral("Hello", "en-gb");
+        final Literal upper = factory.createLiteral("Hello", "EN-GB");
+        final Literal mixed = factory.createLiteral("Hello", "en-GB");
+
+        final IRI example1 = factory.createIRI("http://example.com/s1");
+        final IRI greeting = factory.createIRI("http://example.com/greeting");
+
+        final Graph graph = factory.createGraph();
+        graph.add(example1, greeting, upper);
+
+        assertTrue(graph.contains(factory.createTriple(example1, greeting, upper)));
+        assertTrue(graph.contains(factory.createTriple(example1, greeting, lower)));
+        assertTrue(graph.contains(factory.createTriple(example1, greeting, mixed)));
+
+        // or as patterns
+        assertTrue(graph.contains(null, null, upper));
+        assertTrue(graph.contains(null, null, lower));
+        assertTrue(graph.contains(null, null, mixed));
+
+        // Remove should also honour any case
+        graph.remove(example1, greeting, mixed);
+        assertFalse(graph.contains(null, greeting, null));
+    }
+
+    @Test
+    public void containsLanguageTagsCaseInsensitiveTurkish() {
+        // COMMONSRDF-51: Special test for Turkish issue where
+        // "i".toLowerCase() != "i"
+        // See also:
+        // https://garygregory.wordpress.com/2015/11/03/java-lowercase-conversion-turkey/
+
+        // This is similar to the test in AbstractRDFTest, but on a graph
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.ROOT);
+            final Literal lowerROOT = factory.createLiteral("moi", "fi");
+            final Literal upperROOT = factory.createLiteral("moi", "FI");
+            final Literal mixedROOT = factory.createLiteral("moi", "fI");
+            final Graph g = factory.createGraph();
+            final IRI exampleROOT = factory.createIRI("http://example.com/s1");
+            final IRI greeting = factory.createIRI("http://example.com/greeting");
+            g.add(exampleROOT, greeting, mixedROOT);
+
+            Locale turkish = Locale.forLanguageTag("TR");
+            Locale.setDefault(turkish);
+            // If the below assertion fails, then the Turkish
+            // locale no longer have this peculiarity that
+            // we want to test.
+            Assume.assumeFalse("FI".toLowerCase().equals("fi"));
+
+            // Below is pretty much the same as in
+            // containsLanguageTagsCaseInsensitive()
+            final Literal lower = factory.createLiteral("moi", "fi");
+            final Literal upper = factory.createLiteral("moi", "FI");
+            final Literal mixed = factory.createLiteral("moi", "fI");
+
+            final IRI exampleTR = factory.createIRI("http://example.com/s2");
+            g.add(exampleTR, greeting, upper);
+            assertTrue(g.contains(factory.createTriple(exampleTR, greeting, upper)));
+            assertTrue(g.contains(factory.createTriple(exampleTR, greeting, upperROOT)));
+            assertTrue(g.contains(factory.createTriple(exampleTR, greeting, lower)));
+            assertTrue(g.contains(factory.createTriple(exampleTR, greeting, lowerROOT)));
+            assertTrue(g.contains(factory.createTriple(exampleTR, greeting, mixed)));
+            assertTrue(g.contains(factory.createTriple(exampleTR, greeting, mixedROOT)));
+            assertTrue(g.contains(exampleTR, null, upper));
+            assertTrue(g.contains(exampleTR, null, upperROOT));
+            assertTrue(g.contains(exampleTR, null, lower));
+            assertTrue(g.contains(exampleTR, null, lowerROOT));
+            assertTrue(g.contains(exampleTR, null, mixed));
+            assertTrue(g.contains(exampleTR, null, mixedROOT));
+            g.remove(exampleTR, greeting, mixed);
+            assertFalse(g.contains(exampleTR, null, null));
+
+            // What about the triple we added while in ROOT locale?
+            assertTrue(g.contains(factory.createTriple(exampleROOT, greeting, upper)));
+            assertTrue(g.contains(factory.createTriple(exampleROOT, greeting, lower)));
+            assertTrue(g.contains(factory.createTriple(exampleROOT, greeting, mixed)));
+            assertTrue(g.contains(exampleROOT, null, upper));
+            assertTrue(g.contains(exampleROOT, null, lower));
+            assertTrue(g.contains(exampleROOT, null, mixed));
+            g.remove(exampleROOT, greeting, mixed);
+            assertFalse(g.contains(exampleROOT, null, null));
+
+
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+
+    }
+
     private void notEquals(final BlankNodeOrIRI node1, final BlankNodeOrIRI node2) {
         assertFalse(node1.equals(node2));
         // in which case we should be able to assume
@@ -439,7 +534,7 @@ public abstract class AbstractGraphTest {
      * Create a different implementation of BlankNode to be tested with
      * graph.add(a,b,c); (the implementation may or may not then choose to
      * translate such to its own instances)
-     * 
+     *
      * @param name
      * @return
      */
@@ -493,7 +588,7 @@ public abstract class AbstractGraphTest {
      * An attempt to use the Java 8 streams to look up a more complicated query.
      * <p>
      * FYI, the equivalent SPARQL version (untested):
-     * 
+     *
      * <pre>
      *     SELECT ?orgName WHERE {
      *             ?org foaf:name ?orgName .

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -399,7 +399,8 @@ public abstract class AbstractGraphTest {
 
         final Graph graph = factory.createGraph();
         graph.add(example1, greeting, upper);
-
+        
+        // any kind of Triple should match
         assertTrue(graph.contains(factory.createTriple(example1, greeting, upper)));
         assertTrue(graph.contains(factory.createTriple(example1, greeting, lower)));
         assertTrue(graph.contains(factory.createTriple(example1, greeting, mixed)));
@@ -491,8 +492,10 @@ public abstract class AbstractGraphTest {
         graph.add(example1, greeting, lower);
         graph.remove(example1, null, upper);
 
+        // Check with Triple
         graph.add(factory.createTriple(example1, greeting, mixed));
         graph.remove(factory.createTriple(example1, greeting, upper));
+        assertFalse(graph.contains(null, greeting, null));
     }
 
     private static Optional<? extends Triple> closableFindAny(Stream<? extends Triple> stream) {

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -408,13 +408,6 @@ public abstract class AbstractGraphTest {
         assertTrue(graph.contains(null, null, upper));
         assertTrue(graph.contains(null, null, lower));
         assertTrue(graph.contains(null, null, mixed));
-
-        // Remove should also honour any case
-        graph.remove(example1, null, mixed);
-//        Triple t = graph.stream().findAny().get();
-//        System.out.println(t);
-        // no more greetings of any kind
-        assertFalse(graph.contains(null, greeting, null));
     }
 
     @Test
@@ -463,9 +456,6 @@ public abstract class AbstractGraphTest {
             assertTrue(g.contains(exampleTR, null, lowerROOT));
             assertTrue(g.contains(exampleTR, null, mixed));
             assertTrue(g.contains(exampleTR, null, mixedROOT));
-            g.remove(exampleTR, null, mixed);
-            // No more greetings for exampleTR
-            assertFalse(g.contains(exampleTR, null, null));
 
             // What about the triple we added while in ROOT locale?
             assertTrue(g.contains(factory.createTriple(exampleROOT, greeting, upper)));
@@ -474,15 +464,59 @@ public abstract class AbstractGraphTest {
             assertTrue(g.contains(exampleROOT, null, upper));
             assertTrue(g.contains(exampleROOT, null, lower));
             assertTrue(g.contains(exampleROOT, null, mixed));
-            g.remove(exampleROOT, null, mixed);
-            // No more greetings of any kind
-            assertFalse(g.contains(null, null, null));
-
-
         } finally {
             Locale.setDefault(defaultLocale);
         }
+    }
+    
 
+    @Test
+    public void removeLanguageTagsCaseInsensitive() {
+        // COMMONSRDF-51: Ensure we can remove with any casing
+        // of literal language tag
+        final Literal lower = factory.createLiteral("Hello", "en-gb");
+        final Literal upper = factory.createLiteral("Hello", "EN-GB");
+        final Literal mixed = factory.createLiteral("Hello", "en-GB");
+
+        final IRI example1 = factory.createIRI("http://example.com/s1");
+        final IRI greeting = factory.createIRI("http://example.com/greeting");
+
+        final Graph graph = factory.createGraph();
+        graph.add(example1, greeting, upper);
+
+        // Remove should also honour any case
+        graph.remove(example1, null, mixed);
+        assertFalse(graph.contains(null, greeting, null));
+        
+        graph.add(example1, greeting, lower);
+        graph.remove(example1, null, upper);
+
+        graph.add(factory.createTriple(example1, greeting, mixed));
+        graph.remove(factory.createTriple(example1, greeting, upper));
+    }
+
+    @Test
+    public void streamLanguageTagsCaseInsensitive() {
+        // COMMONSRDF-51: Ensure we can add/contains/remove with any casing
+        // of literal language tag
+        final Literal lower = factory.createLiteral("Hello", "en-gb");
+        final Literal upper = factory.createLiteral("Hello", "EN-GB");
+        final Literal mixed = factory.createLiteral("Hello", "en-GB");
+
+        final IRI example1 = factory.createIRI("http://example.com/s1");
+        final IRI greeting = factory.createIRI("http://example.com/greeting");
+
+        final Graph graph = factory.createGraph();
+        graph.add(example1, greeting, upper);
+
+        // or as patterns
+        assertTrue(graph.stream(null, null, upper).findAny().isPresent());
+        assertTrue(graph.stream(null, null, lower).findAny().isPresent());
+        assertTrue(graph.stream(null, null, mixed).findAny().isPresent());
+        
+        // Check the triples returned equal a new triple
+        Triple t = graph.stream(null, null, lower).findAny().get();
+        assertEquals(t, factory.createTriple(example1, greeting, mixed));
     }
 
     private void notEquals(final BlankNodeOrIRI node1, final BlankNodeOrIRI node2) {

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -411,6 +411,8 @@ public abstract class AbstractGraphTest {
 
         // Remove should also honour any case
         graph.remove(example1, null, mixed);
+//        Triple t = graph.stream().findAny().get();
+//        System.out.println(t);
         // no more greetings of any kind
         assertFalse(graph.contains(null, greeting, null));
     }

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -495,6 +495,12 @@ public abstract class AbstractGraphTest {
         graph.remove(factory.createTriple(example1, greeting, upper));
     }
 
+    private static Optional<? extends Triple> closableFindAny(Stream<? extends Triple> stream) {
+        try (Stream<? extends Triple> s = stream) {
+            return s.findAny();
+        }
+    }
+    
     @Test
     public void streamLanguageTagsCaseInsensitive() {
         // COMMONSRDF-51: Ensure we can add/contains/remove with any casing
@@ -510,12 +516,12 @@ public abstract class AbstractGraphTest {
         graph.add(example1, greeting, upper);
 
         // or as patterns
-        assertTrue(graph.stream(null, null, upper).findAny().isPresent());
-        assertTrue(graph.stream(null, null, lower).findAny().isPresent());
-        assertTrue(graph.stream(null, null, mixed).findAny().isPresent());
+        assertTrue(closableFindAny(graph.stream(null, null, upper)).isPresent());
+        assertTrue(closableFindAny(graph.stream(null, null, lower)).isPresent());
+        assertTrue(closableFindAny(graph.stream(null, null, mixed)).isPresent());
         
         // Check the triples returned equal a new triple
-        Triple t = graph.stream(null, null, lower).findAny().get();
+        Triple t = closableFindAny(graph.stream(null, null, lower)).get();
         assertEquals(t, factory.createTriple(example1, greeting, mixed));
     }
 

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -410,7 +410,8 @@ public abstract class AbstractGraphTest {
         assertTrue(graph.contains(null, null, mixed));
 
         // Remove should also honour any case
-        graph.remove(example1, greeting, mixed);
+        graph.remove(example1, null, mixed);
+        // no more greetings of any kind
         assertFalse(graph.contains(null, greeting, null));
     }
 
@@ -460,7 +461,8 @@ public abstract class AbstractGraphTest {
             assertTrue(g.contains(exampleTR, null, lowerROOT));
             assertTrue(g.contains(exampleTR, null, mixed));
             assertTrue(g.contains(exampleTR, null, mixedROOT));
-            g.remove(exampleTR, greeting, mixed);
+            g.remove(exampleTR, null, mixed);
+            // No more greetings for exampleTR
             assertFalse(g.contains(exampleTR, null, null));
 
             // What about the triple we added while in ROOT locale?
@@ -470,8 +472,9 @@ public abstract class AbstractGraphTest {
             assertTrue(g.contains(exampleROOT, null, upper));
             assertTrue(g.contains(exampleROOT, null, lower));
             assertTrue(g.contains(exampleROOT, null, mixed));
-            g.remove(exampleROOT, greeting, mixed);
-            assertFalse(g.contains(exampleROOT, null, null));
+            g.remove(exampleROOT, null, mixed);
+            // No more greetings of any kind
+            assertFalse(g.contains(null, null, null));
 
 
         } finally {

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractRDFTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractRDFTest.java
@@ -194,6 +194,7 @@ public abstract class AbstractRDFTest {
         assertEquals("\"Herbert Van de Sompel\"@vls", vls.ntriplesString());
     }
 
+    @Test
     public void testCreateLiteralLangCaseInsensitive() throws Exception {
         // COMMONSRDF-51: Literal langtag may not be in lowercase, but
         // must be COMPARED (aka .equals and .hashCode()) in lowercase
@@ -415,4 +416,5 @@ public abstract class AbstractRDFTest {
         final Triple triple = factory.createTriple(iri, iri, iri);
         assertEquals(Objects.hash(iri, iri, iri), triple.hashCode());
     }
+
 }

--- a/api/src/test/java/org/apache/commons/rdf/api/AbstractRDFTest.java
+++ b/api/src/test/java/org/apache/commons/rdf/api/AbstractRDFTest.java
@@ -209,8 +209,8 @@ public abstract class AbstractRDFTest {
          * COMPARED (aka .equals and .hashCode()) in lowercase as the language
          * space is lower case.
          */
-        final Literal lower = factory.createLiteral("Hello", "en-gb");
         final Literal upper = factory.createLiteral("Hello", "EN-GB");
+        final Literal lower = factory.createLiteral("Hello", "en-gb");
         final Literal mixed = factory.createLiteral("Hello", "en-GB");
 
         /*
@@ -251,14 +251,14 @@ public abstract class AbstractRDFTest {
         // COMMONSRDF-51: Ensure the Literal is using case insensitive
         // comparison against any literal implementation
         // which may not have done .toLowerString() in their constructor
-        final Literal lower = factory.createLiteral("Hello", "en-gb");
         final Literal upper = factory.createLiteral("Hello", "EN-GB");
+        final Literal lower = factory.createLiteral("Hello", "en-gb");
         final Literal mixed = factory.createLiteral("Hello", "en-GB");
 
         Literal otherLiteral = new Literal() {
             @Override
             public String ntriplesString() {
-                return "Hello@en-GB";
+                return "Hello@eN-Gb";
             }
             @Override
             public String getLexicalForm() {
@@ -266,7 +266,7 @@ public abstract class AbstractRDFTest {
             }
             @Override
             public Optional<String> getLanguageTag() {
-                return Optional.of("en-GB");
+                return Optional.of("eN-Gb");
             }
             @Override
             public IRI getDatatype() {
@@ -294,9 +294,9 @@ public abstract class AbstractRDFTest {
         Locale defaultLocale = Locale.getDefault();
         try {
             Locale.setDefault(Locale.ROOT);
+            final Literal mixedROOT = factory.createLiteral("moi", "fI");
             final Literal lowerROOT = factory.createLiteral("moi", "fi");
             final Literal upperROOT = factory.createLiteral("moi", "FI");
-            final Literal mixedROOT = factory.createLiteral("moi", "fI");
 
             Locale turkish = Locale.forLanguageTag("TR");
             Locale.setDefault(turkish);
@@ -305,9 +305,9 @@ public abstract class AbstractRDFTest {
             // we want to test.
             Assume.assumeFalse("FI".toLowerCase().equals("fi"));
 
+            final Literal mixed = factory.createLiteral("moi", "fI");
             final Literal lower = factory.createLiteral("moi", "fi");
             final Literal upper = factory.createLiteral("moi", "FI");
-            final Literal mixed = factory.createLiteral("moi", "fI");
 
             assertEquals(lower, lower);
             assertEqualsBothWays(lower, upper);

--- a/jena/src/main/java/org/apache/commons/rdf/jena/impl/JenaDatasetImpl.java
+++ b/jena/src/main/java/org/apache/commons/rdf/jena/impl/JenaDatasetImpl.java
@@ -117,12 +117,12 @@ class JenaDatasetImpl implements JenaDataset {
 
     @Override
     public void remove(final Quad quad) {
+        // COMMONSRDF-51: 
         graph.deleteAny(
                 toJenaPattern(quad.getGraphName()),
                 toJenaPattern(quad.getSubject()),
                 toJenaPattern(quad.getPredicate()),
                 toJenaPattern(quad.getObject()));
-//        graph.delete(factory.asJenaQuad(quad));
     }
 
     @Override

--- a/jena/src/main/java/org/apache/commons/rdf/jena/impl/JenaDatasetImpl.java
+++ b/jena/src/main/java/org/apache/commons/rdf/jena/impl/JenaDatasetImpl.java
@@ -117,7 +117,12 @@ class JenaDatasetImpl implements JenaDataset {
 
     @Override
     public void remove(final Quad quad) {
-        graph.delete(factory.asJenaQuad(quad));
+        graph.deleteAny(
+                toJenaPattern(quad.getGraphName()),
+                toJenaPattern(quad.getSubject()),
+                toJenaPattern(quad.getPredicate()),
+                toJenaPattern(quad.getObject()));
+//        graph.delete(factory.asJenaQuad(quad));
     }
 
     @Override

--- a/jena/src/main/java/org/apache/commons/rdf/jena/impl/JenaGraphImpl.java
+++ b/jena/src/main/java/org/apache/commons/rdf/jena/impl/JenaGraphImpl.java
@@ -29,7 +29,6 @@ import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.commons.rdf.api.Triple;
 import org.apache.commons.rdf.jena.JenaGraph;
 import org.apache.commons.rdf.jena.JenaRDF;
-import org.apache.commons.rdf.jena.JenaTriple;
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Model;

--- a/jena/src/main/java/org/apache/commons/rdf/jena/impl/JenaLiteralImpl.java
+++ b/jena/src/main/java/org/apache/commons/rdf/jena/impl/JenaLiteralImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.commons.rdf.jena.impl;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -37,6 +38,10 @@ class JenaLiteralImpl extends AbstractJenaRDFTerm implements JenaLiteral {
             throw new IllegalArgumentException("Node is not a literal: " + node);
         }
     }
+    
+    private static String lowerCase(String langTag) { 
+        return langTag.toLowerCase(Locale.ROOT);
+    }
 
     @Override
     public boolean equals(final Object other) {
@@ -50,8 +55,10 @@ class JenaLiteralImpl extends AbstractJenaRDFTerm implements JenaLiteral {
             return false;
         }
         final Literal literal = (Literal) other;
-        return getLexicalForm().equals(literal.getLexicalForm()) && getLanguageTag().equals(literal.getLanguageTag())
-                && getDatatype().equals(literal.getDatatype());
+        return getLexicalForm().equals(literal.getLexicalForm()) &&
+                getDatatype().equals(literal.getDatatype()) &&
+                getLanguageTag().map(JenaLiteralImpl::lowerCase).equals(
+                        literal.getLanguageTag().map(JenaLiteralImpl::lowerCase));
     }
 
     @Override
@@ -75,6 +82,6 @@ class JenaLiteralImpl extends AbstractJenaRDFTerm implements JenaLiteral {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getLexicalForm(), getDatatype(), getLanguageTag());
+        return Objects.hash(getLexicalForm(), getDatatype(), getLanguageTag().map(JenaLiteralImpl::lowerCase));
     }
 }

--- a/jsonld-java/src/main/java/org/apache/commons/rdf/jsonldjava/JsonLdLiteral.java
+++ b/jsonld-java/src/main/java/org/apache/commons/rdf/jsonldjava/JsonLdLiteral.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.rdf.jsonldjava;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -38,6 +39,10 @@ class JsonLdLiteralImpl extends JsonLdTermImpl implements JsonLdLiteral {
         }
     }
 
+    private static String lowerCase(String langTag) { 
+        return langTag.toLowerCase(Locale.ROOT);
+    }
+    
     @Override
     public String ntriplesString() {
         final StringBuilder sb = new StringBuilder();
@@ -76,9 +81,8 @@ class JsonLdLiteralImpl extends JsonLdTermImpl implements JsonLdLiteral {
 
     @Override
     public int hashCode() {
-        // Should be the same as
-        // Objects.hash(getLexicalForm(), getDatatype(), getLanguageTag());
-        return Objects.hash(node.getValue(), node.getDatatype(), node.getLanguage());
+        return Objects.hash(node.getValue(), node.getDatatype(), 
+                getLanguageTag().map(JsonLdLiteralImpl::lowerCase));
     }
 
     @Override
@@ -90,7 +94,8 @@ class JsonLdLiteralImpl extends JsonLdTermImpl implements JsonLdLiteral {
         if (obj instanceof Literal) {
             final Literal other = (Literal) obj;
             return getLexicalForm().equals(other.getLexicalForm()) && getDatatype().equals(other.getDatatype())
-                    && getLanguageTag().equals(other.getLanguageTag());
+                    && getLanguageTag().map(JsonLdLiteralImpl::lowerCase)
+                    .equals(other.getLanguageTag().map(JsonLdLiteralImpl::lowerCase));
         }
         return false;
 

--- a/rdf4j/src/main/java/org/apache/commons/rdf/rdf4j/impl/LiteralImpl.java
+++ b/rdf4j/src/main/java/org/apache/commons/rdf/rdf4j/impl/LiteralImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.commons.rdf.rdf4j.impl;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -32,6 +33,10 @@ final class LiteralImpl extends AbstractRDFTerm<org.eclipse.rdf4j.model.Literal>
         super(literal);
     }
 
+    private static String lowerCase(String langTag) { 
+        return langTag.toLowerCase(Locale.ROOT);
+    }
+    
     @Override
     public boolean equals(final Object obj) {
         if (obj == this) {
@@ -39,9 +44,10 @@ final class LiteralImpl extends AbstractRDFTerm<org.eclipse.rdf4j.model.Literal>
         }
         if (obj instanceof org.apache.commons.rdf.api.Literal) {
             final org.apache.commons.rdf.api.Literal other = (org.apache.commons.rdf.api.Literal) obj;
-            return getLexicalForm().equals(other.getLexicalForm()) && getDatatype().equals(other.getDatatype())
-                    && getLanguageTag().equals(other.getLanguageTag());
-
+            return getLexicalForm().equals(other.getLexicalForm()) && 
+                    getDatatype().equals(other.getDatatype()) &&
+                    getLanguageTag().map(LiteralImpl::lowerCase).equals(
+                            other.getLanguageTag().map(LiteralImpl::lowerCase));
         }
         return false;
     }
@@ -63,7 +69,8 @@ final class LiteralImpl extends AbstractRDFTerm<org.eclipse.rdf4j.model.Literal>
 
     @Override
     public int hashCode() {
-        return Objects.hash(value.getLabel(), value.getDatatype(), value.getLanguage());
+        return Objects.hash(value.getLabel(), value.getDatatype(), 
+                getLanguageTag().map(LiteralImpl::lowerCase));
     }
 
     @Override

--- a/simple/src/main/java/org/apache/commons/rdf/simple/LiteralImpl.java
+++ b/simple/src/main/java/org/apache/commons/rdf/simple/LiteralImpl.java
@@ -52,7 +52,7 @@ final class LiteralImpl implements Literal, SimpleRDF.SimpleRDFTerm {
 
     public LiteralImpl(final String literal, final String languageTag) {
         this.lexicalForm = Objects.requireNonNull(literal);
-        this.languageTag = Objects.requireNonNull(languageTag).toLowerCase(Locale.ENGLISH);
+        this.languageTag = Objects.requireNonNull(lowerCase(languageTag));
         if (languageTag.isEmpty()) {
             // TODO: Check against
             // http://www.w3.org/TR/n-triples/#n-triples-grammar
@@ -116,6 +116,10 @@ final class LiteralImpl implements Literal, SimpleRDF.SimpleRDFTerm {
         return Objects.hash(lexicalForm, dataType, languageTag);
     }
 
+    private static String lowerCase(String langTag) { 
+        return langTag.toLowerCase(Locale.ROOT);
+    }
+    
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -126,7 +130,7 @@ final class LiteralImpl implements Literal, SimpleRDF.SimpleRDFTerm {
         }
         final Literal literal = (Literal) obj;
         return getDatatype().equals(literal.getDatatype()) && getLexicalForm().equals(literal.getLexicalForm())
-                && getLanguageTag().equals(literal.getLanguageTag());
+                && getLanguageTag().equals(literal.getLanguageTag().map(LiteralImpl::lowerCase));
     }
 
 }


### PR DESCRIPTION
This fixes [COMMONSRDF-51](https://issues.apache.org/jira/browse/COMMONSRDF-51) - at least from `Literal.equals()` and `Literal.hashCode()`

Further test might be needed to verify consistent behaviour in `Graph` and `Dataset` if underlying framework does not correctly do langtag comparison in lower case (e.g. Turkish locale problem).

Please comment on the fixes and the suggested updated javadoc:

* [Literal.equals(Object)](http://stain.github.io/commons-rdf/COMMONSRDF-51/org/apache/commons/rdf/api/Literal.html#equals-java.lang.Object-)
* [Literal.hashCode()](http://stain.github.io/commons-rdf/COMMONSRDF-51/org/apache/commons/rdf/api/Literal.html#hashCode--)
* [Literal.getLanguageTag()](http://stain.github.io/commons-rdf/COMMONSRDF-51/org/apache/commons/rdf/api/Literal.html#getLanguageTag--)

For code improvements of this PR, feel free to push to the `COMMONSRDF-51-langtag-lcase` branch at https://git-wip-us.apache.org/repos/asf/commons-rdf.git or use the "Start review" mechanism in GitHub.

