### PR TITLE
COMMONSRDF-55: Handle Jena's urn:x-arq:DefaultGraph and friends

### DIFF
--- a/jena/src/main/java/org/apache/commons/rdf/jena/JenaRDF.java
+++ b/jena/src/main/java/org/apache/commons/rdf/jena/JenaRDF.java
@@ -151,6 +151,18 @@ public final class JenaRDF implements RDF {
         return internalJenaFactory.createTriple(subject, predicate, object);
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * In addition to supporting a <code>graphName</code> of <code>null</code>
+     * for representing a triple in the <em>default graph</em>, this method also
+     * recognize a {@link JenaIRI} which {@link JenaRDFTerm#asJenaNode()}
+     * represent the default graph according to
+     * {@link org.apache.jena.sparql.core.Quad#isDefaultGraph(Node)}, in which
+     * case the returned JenaQuad will have a {@link Quad#getGraphName()} of
+     * {@link Optional#empty()} rather than the provided IRI.
+     * 
+     */
     @Override
     public JenaQuad createQuad(final BlankNodeOrIRI graphName, final BlankNodeOrIRI subject, final IRI predicate, final RDFTerm object)
             throws IllegalArgumentException, UnsupportedOperationException {
@@ -187,6 +199,14 @@ public final class JenaRDF implements RDF {
      * The <em>generalized quad</em> supports any {@link RDFTerm} as its
      * {@link QuadLike#getSubject()} {@link QuadLike#getPredicate()},
      * {@link QuadLike#getObject()} or {@link QuadLike#getObject()}.
+     * <p>
+     * In addition to supporting a <code>graphName</code> of <code>null</code>
+     * for representing a triple in the <em>default graph</em>, this method also
+     * recognize a {@link JenaIRI} which {@link JenaRDFTerm#asJenaNode()}
+     * represent the default graph according to
+     * {@link org.apache.jena.sparql.core.Quad#isDefaultGraph(Node)}, in which
+     * case the returned JenaQuad will have a {@link Quad#getGraphName()} of
+     * {@link Optional#empty()} rather than the provided IRI.
      * 
      * @see #createQuad(BlankNodeOrIRI, BlankNodeOrIRI, IRI, RDFTerm)
      * @see #createGeneralizedTriple(RDFTerm, RDFTerm, RDFTerm)
@@ -345,6 +365,10 @@ public final class JenaRDF implements RDF {
      * {@link JenaRDF} instance in combination with
      * {@link Node#getBlankNodeId()} for the purpose of its
      * {@link BlankNode#uniqueReference()}.
+     * <p>
+     * If the provided quad {@link org.apache.jena.sparql.core.Quad#isDefaultGraph()},
+     * the returned {@link JenaQuadLike} has a {@link JenaQuadLike#getGraphName()} 
+     * of {@link Optional#empty()}.
      *
      * @see #asQuad(org.apache.jena.sparql.core.Quad)
      * @see #asGeneralizedTriple(org.apache.jena.graph.Triple)
@@ -407,6 +431,10 @@ public final class JenaRDF implements RDF {
      * {@link BlankNode} will use a {@link UUID} salt from this {@link JenaRDF}
      * instance in combination with {@link Node#getBlankNodeId()} for the
      * purpose of its {@link BlankNode#uniqueReference()}.
+     * <p>
+     * If the provided quad {@link org.apache.jena.sparql.core.Quad#isDefaultGraph()},
+     * the returned {@link JenaQuad} has a {@link Quad#getGraphName()} 
+     * of {@link Optional#empty()}.
      * 
      * @param quad
      *            Jena quad
@@ -510,6 +538,10 @@ public final class JenaRDF implements RDF {
      * factory's {@link RDF#createBlankNode(String)} will be used, meaning that
      * care should be taken if reusing an {@link RDF} instance for multiple
      * conversion sessions.
+     * <p>
+     * If the provided quad {@link org.apache.jena.sparql.core.Quad#isDefaultGraph()},
+     * the returned {@link JenaQuadLike} has a {@link JenaQuadLike#getGraphName()} 
+     * of {@link Optional#empty()}.
      * 
      * @see #asQuad(org.apache.jena.sparql.core.Quad)
      * @see #asGeneralizedQuad(org.apache.jena.sparql.core.Quad)

--- a/jena/src/main/java/org/apache/commons/rdf/jena/impl/AbstractQuadLike.java
+++ b/jena/src/main/java/org/apache/commons/rdf/jena/impl/AbstractQuadLike.java
@@ -22,15 +22,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.commons.rdf.api.BlankNodeOrIRI;
-import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.QuadLike;
 import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.commons.rdf.jena.JenaQuad;
 import org.apache.commons.rdf.jena.JenaQuadLike;
 import org.apache.commons.rdf.jena.JenaRDF;
 import org.apache.commons.rdf.jena.JenaTriple;
-import org.apache.jena.graph.Factory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.core.Quad;
 
@@ -57,6 +54,12 @@ abstract class AbstractQuadLike<S extends RDFTerm, P extends RDFTerm, O extends 
 
     /**
      * COMMONSRDF-55 - special handling of urn:x-arq:DefaultGraph and friends
+     * <p>
+     * This can recognize <urn:x-arq:DefaultGraph> and
+     * <urn:x-arq:DefaultGraphNode> from any IRI instance, so they can be
+     * replaced with Optional.empty(). Note that this code does not hardcode the
+     * internal Jena IRIs but uses Jena's constants {@link Quad#defaultGraphIRI}
+     * and {@link Quad#defaultGraphNodeGenerated}.
      */
     private static class DefaultGraphChecker {
         // Fixed UUID for comparison of defaultGraphNodeGenerated

--- a/jena/src/main/java/org/apache/commons/rdf/jena/impl/InternalJenaFactory.java
+++ b/jena/src/main/java/org/apache/commons/rdf/jena/impl/InternalJenaFactory.java
@@ -159,7 +159,7 @@ public abstract class InternalJenaFactory {
         }
         throw new ConversionException("Unrecognized node type: " + node);
     }
-
+    
     public JenaTriple createTriple(final BlankNodeOrIRI subject, final IRI predicate, final RDFTerm object) {
         return new JenaTripleImpl(subject, predicate, object);
     }

--- a/jena/src/test/java/org/apache/commons/rdf/jena/DefaultGraphInQuadTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/DefaultGraphInQuadTest.java
@@ -29,12 +29,13 @@ import org.apache.jena.sparql.core.Quad;
 import org.junit.Test;
 
 /**
- * COMMONSRDF-55: Ensure correct handling of 
+ * COMMONSRDF-55: Handling of 
  * Jena's default graph IRI urn:x-arq:DefaultGraph
  */
 public class DefaultGraphInQuadTest {
     
     JenaRDF rdf = new JenaRDF();
+    SimpleRDF simpleRDF = new SimpleRDF();
     IRI example = rdf.createIRI("http://example.com/");
     Node exampleJena = NodeFactory.createURI("http://example.com/");
     
@@ -50,19 +51,28 @@ public class DefaultGraphInQuadTest {
     public void createFromDefaultGraphIRI() throws Exception {
         JenaIRI defaultGraph = (JenaIRI) rdf.asRDFTerm(Quad.defaultGraphIRI);        
         JenaQuad q = rdf.createQuad(defaultGraph, example, example, example);
+        // NOTE: JenaRDF specially recognize this JenaIRI constant, 
+        // even if this breaks the SHOULD of RDF.createQuad()
         assertTrue(q.asJenaQuad().isDefaultGraph());
         assertEquals(Quad.defaultGraphIRI,  q.asJenaQuad().getGraph());
         assertFalse(q.getGraphName().isPresent());
+        // thus we can't require 
+        //assertEquals(defaultGraph, q.getGraphName().get());
     }
 
     @Test
     public void createFromForeignDefaultGraph() throws Exception {
         // What if <urn:x-arq:DefaultGraph> appear in a non-Jena IRI?
-        IRI foreignDefaultGraph = new SimpleRDF().createIRI(Quad.defaultGraphIRI.getURI());
+        IRI foreignDefaultGraph = simpleRDF.createIRI(Quad.defaultGraphIRI.getURI());
         JenaQuad q = rdf.createQuad(foreignDefaultGraph, example, example, example);
+        // As the IRI was NOT a JenaIRI we preserve it as-is,
+        // rather than replacing it with Optional.empty()        
         assertTrue(q.asJenaQuad().isDefaultGraph());
+        assertTrue(q.getGraphName().isPresent()); // INCONSISTENT with above
         assertEquals(Quad.defaultGraphIRI,  q.asJenaQuad().getGraph());
-        assertFalse(q.getGraphName().isPresent());
+        assertEquals(foreignDefaultGraph, q.getGraphName().get());
+        // Note that adding such a quad to a Dataset would still "convert" it to
+        // Optional.empty() 
     }
     
 
@@ -71,23 +81,25 @@ public class DefaultGraphInQuadTest {
         // What if <urn:x-arq:DefaultGraphNode> appear as an IRI instance?
         IRI foreignDefaultGraph = rdf.createIRI(Quad.defaultGraphNodeGenerated.getURI());
         JenaQuad q = rdf.createQuad(foreignDefaultGraph, example, example, example);
+        // NOTE: JenaRDF specially recognize this JenaIRI constant, 
+        // even if this breaks the SHOULD of RDF.createQuad()
         assertTrue(q.asJenaQuad().isDefaultGraph());
-        assertFalse(q.getGraphName().isPresent());
-        // Unfortunately  Quad.defaultGraphNodeGenerated is not preserved
-        // within JenaQuad
+        assertFalse(q.getGraphName().isPresent()); // CONSISTENT with above 
+        // Unfortunately Quad.defaultGraphNodeGenerated is not preserved:
         //assertEquals(Quad.defaultGraphNodeGenerated, q.asJenaQuad().getGraph());
     }
 
     @Test
     public void createFromDefaultGraphNodeGeneratedIRIString() throws Exception {
         // What if <urn:x-arq:DefaultGraphNode> appear in a non-Jena IRI?
-        IRI foreignDefaultGraph = (IRI) rdf.asRDFTerm((Quad.defaultGraphNodeGenerated));
+        IRI foreignDefaultGraph = (IRI) simpleRDF.createIRI(Quad.defaultGraphNodeGenerated.getURI());
         JenaQuad q = rdf.createQuad(foreignDefaultGraph, example, example, example);
-        assertTrue(q.asJenaQuad().isDefaultGraph());
-        assertFalse(q.getGraphName().isPresent());
-        // Unfortunately  Quad.defaultGraphNodeGenerated is not preserved
-        // within JenaQuad
-        assertEquals(Quad.defaultGraphNodeGenerated, q.asJenaQuad().getGraph());
+        // We'll expect JenaRDF to preserve the graph IRI as-is        
+        assertTrue(q.asJenaQuad().isDefaultGraph()); 
+        assertTrue(q.getGraphName().isPresent()); // INCONSISTENT WITH above
+        // Now Quad.defaultGraphNodeGenerated is preserved at both ends
+        assertEquals(Quad.defaultGraphNodeGenerated,  q.asJenaQuad().getGraph());
+        assertEquals(foreignDefaultGraph, q.getGraphName().get());
     }
 
     

--- a/jena/src/test/java/org/apache/commons/rdf/jena/DefaultGraphInQuadTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/DefaultGraphInQuadTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.simple.SimpleRDF;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Quad;
@@ -53,6 +54,42 @@ public class DefaultGraphInQuadTest {
         assertEquals(Quad.defaultGraphIRI,  q.asJenaQuad().getGraph());
         assertFalse(q.getGraphName().isPresent());
     }
+
+    @Test
+    public void createFromForeignDefaultGraph() throws Exception {
+        // What if <urn:x-arq:DefaultGraph> appear in a non-Jena IRI?
+        IRI foreignDefaultGraph = new SimpleRDF().createIRI(Quad.defaultGraphIRI.getURI());
+        JenaQuad q = rdf.createQuad(foreignDefaultGraph, example, example, example);
+        assertTrue(q.asJenaQuad().isDefaultGraph());
+        assertEquals(Quad.defaultGraphIRI,  q.asJenaQuad().getGraph());
+        assertFalse(q.getGraphName().isPresent());
+    }
+    
+
+    @Test
+    public void createFromDefaultGraphNodeGeneratedIRINode() throws Exception {
+        // What if <urn:x-arq:DefaultGraphNode> appear as an IRI instance?
+        IRI foreignDefaultGraph = rdf.createIRI(Quad.defaultGraphNodeGenerated.getURI());
+        JenaQuad q = rdf.createQuad(foreignDefaultGraph, example, example, example);
+        assertTrue(q.asJenaQuad().isDefaultGraph());
+        assertFalse(q.getGraphName().isPresent());
+        // Unfortunately  Quad.defaultGraphNodeGenerated is not preserved
+        // within JenaQuad
+        //assertEquals(Quad.defaultGraphNodeGenerated, q.asJenaQuad().getGraph());
+    }
+
+    @Test
+    public void createFromDefaultGraphNodeGeneratedIRIString() throws Exception {
+        // What if <urn:x-arq:DefaultGraphNode> appear in a non-Jena IRI?
+        IRI foreignDefaultGraph = (IRI) rdf.asRDFTerm((Quad.defaultGraphNodeGenerated));
+        JenaQuad q = rdf.createQuad(foreignDefaultGraph, example, example, example);
+        assertTrue(q.asJenaQuad().isDefaultGraph());
+        assertFalse(q.getGraphName().isPresent());
+        // Unfortunately  Quad.defaultGraphNodeGenerated is not preserved
+        // within JenaQuad
+        assertEquals(Quad.defaultGraphNodeGenerated, q.asJenaQuad().getGraph());
+    }
+
     
     @Test
     public void defaultGraphIRI() throws Exception {
@@ -64,11 +101,13 @@ public class DefaultGraphInQuadTest {
 
     @Test
     public void defaultGraphNodeGenerated() throws Exception {        
-        // defaultGraphNodeGenerated might appear in parser output
+        // <urn:x-arq:DefaultGraphNode> might appear in parser output
         Quad jenaQuad = Quad.create(Quad.defaultGraphNodeGenerated, exampleJena, exampleJena, exampleJena);
         JenaQuad q = rdf.asQuad(jenaQuad);        
         assertFalse(q.getGraphName().isPresent());
         assertTrue(q.asJenaQuad().isDefaultGraph());
+        // Preserves <urn:x-arq:DefaultGraphNode>
+        assertEquals(Quad.defaultGraphNodeGenerated, q.asJenaQuad().getGraph());
     }
 
     @Test

--- a/jena/src/test/java/org/apache/commons/rdf/jena/DefaultGraphInQuadTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/DefaultGraphInQuadTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.jena;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.rdf.api.IRI;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Quad;
+import org.junit.Test;
+
+/**
+ * COMMONSRDF-55: Ensure correct handling of 
+ * Jena's default graph IRI urn:x-arq:DefaultGraph
+ */
+public class DefaultGraphInQuadTest {
+    
+    JenaRDF rdf = new JenaRDF();
+    IRI example = rdf.createIRI("http://example.com/");
+    Node exampleJena = NodeFactory.createURI("http://example.com/");
+    
+    @Test
+    public void createFromNull() throws Exception {        
+        JenaQuad q = rdf.createQuad(null, example, example, example);
+        assertFalse(q.getGraphName().isPresent());
+        assertTrue(q.asJenaQuad().isDefaultGraph());
+        assertEquals(Quad.defaultGraphIRI,  q.asJenaQuad().getGraph());
+    }
+
+    @Test
+    public void createFromDefaultGraphIRI() throws Exception {
+        JenaIRI defaultGraph = (JenaIRI) rdf.asRDFTerm(Quad.defaultGraphIRI);        
+        JenaQuad q = rdf.createQuad(defaultGraph, example, example, example);
+        assertTrue(q.asJenaQuad().isDefaultGraph());
+        assertEquals(Quad.defaultGraphIRI,  q.asJenaQuad().getGraph());
+        assertFalse(q.getGraphName().isPresent());
+    }
+    
+    @Test
+    public void defaultGraphIRI() throws Exception {
+        Quad jenaQuad = Quad.create(Quad.defaultGraphIRI, exampleJena, exampleJena, exampleJena);
+        JenaQuad q = rdf.asQuad(jenaQuad);        
+        assertFalse(q.getGraphName().isPresent());
+        assertTrue(q.asJenaQuad().isDefaultGraph());
+    }
+
+    @Test
+    public void defaultGraphNodeGenerated() throws Exception {        
+        // defaultGraphNodeGenerated might appear in parser output
+        Quad jenaQuad = Quad.create(Quad.defaultGraphNodeGenerated, exampleJena, exampleJena, exampleJena);
+        JenaQuad q = rdf.asQuad(jenaQuad);        
+        assertFalse(q.getGraphName().isPresent());
+        assertTrue(q.asJenaQuad().isDefaultGraph());
+    }
+
+    @Test
+    public void unionGraph() throws Exception {
+        // unionGraph shouldn't really appear as a quad except
+        // in a pattern
+        Quad jenaQuad = Quad.create(Quad.unionGraph, exampleJena, exampleJena, exampleJena);
+        JenaQuad q = rdf.asQuad(jenaQuad);
+        // But at least we can agree it is NOT (necessarily) in the
+        // default graph
+        assertFalse(q.asJenaQuad().isDefaultGraph());
+        assertTrue(q.getGraphName().isPresent());
+    }
+}

--- a/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFQuadTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFQuadTest.java
@@ -17,11 +17,12 @@
  */
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.apache.commons.rdf.api.BlankNode;
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Quad;
 import org.junit.Test;
 
@@ -92,6 +93,19 @@ public class GeneralizedRDFQuadTest {
         assertTrue(q.asJenaQuad().isDefaultGraph());
     }
 
+    @Test
+    public void asGeneralizedQuad() throws Exception {
+        Node s = NodeFactory.createLiteral("Hello");
+        Node p = NodeFactory.createBlankNode();
+        Node o = NodeFactory.createURI("http://example.com/ex");
+        Node g = Quad.defaultGraphIRI;
+        Quad jq = Quad.create(g, s, p, o);
+        JenaQuadLike<RDFTerm> q = jena.asGeneralizedQuad(jq);
+        assertEquals(jena.createLiteral("Hello"), q.getSubject());
+        assertEquals(jena.asRDFTerm(p), q.getPredicate());
+        assertEquals(jena.createIRI("http://example.com/ex"), q.getObject());
+        assertFalse(q.getGraphName().isPresent());
+    }
     
     @Test
     public void literalGraph() throws Exception {
@@ -107,6 +121,7 @@ public class GeneralizedRDFQuadTest {
         assertEquals(lit, q.getGraphName().get()); // it's a literal!
         assertTrue(q.asJenaQuad().getGraph().isLiteral());
     }
+    
     
     
 }

--- a/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFQuadTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFQuadTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.jena;
+
+import static org.junit.Assert.*;
+
+import org.apache.commons.rdf.api.BlankNode;
+import org.junit.Test;
+
+public class GeneralizedRDFQuadTest {
+
+    private JenaRDF jena = new JenaRDF();
+    
+    @Test
+    public void bnodeProperty() throws Exception {
+        BlankNode b1 = jena.createBlankNode("b1");
+        JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
+        JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
+        JenaIRI ex3 = jena.createIRI("http://example.com/ex3");
+        
+        JenaGeneralizedQuadLike t = jena.createGeneralizedQuad(ex1, b1, ex2, ex3);
+        assertEquals(ex1, t.getSubject());
+        assertEquals(ex2, t.getObject());
+        assertEquals(b1, t.getPredicate()); // it's a bnode!
+        assertTrue(t.asJenaQuad().getPredicate().isBlank());
+    }
+
+    @Test
+    public void literalPredicate() throws Exception {
+        JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
+        JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
+        JenaIRI ex3 = jena.createIRI("http://example.com/ex3");
+        JenaLiteral lit = jena.createLiteral("Hello");
+        
+        JenaGeneralizedQuadLike t = jena.createGeneralizedQuad(ex1, lit, ex2, ex3);
+        assertEquals(ex1, t.getSubject());
+        assertEquals(ex2, t.getObject());
+        assertEquals(lit, t.getPredicate()); // it's a literal!
+        assertTrue(t.asJenaQuad().getPredicate().isLiteral());
+    }
+
+
+    @Test
+    public void literalSubject() throws Exception {
+        JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
+        JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
+        JenaIRI ex3 = jena.createIRI("http://example.com/ex3");
+        JenaLiteral lit = jena.createLiteral("Hello");
+        
+        JenaGeneralizedQuadLike t = jena.createGeneralizedQuad(lit, ex1, ex2, ex3);
+        assertEquals(lit, t.getSubject()); // it's a literal!
+        assertEquals(ex1, t.getPredicate());
+        assertEquals(ex2, t.getObject());
+        assertTrue(t.asJenaQuad().getSubject().isLiteral());
+    }
+    
+
+    @Test
+    public void literalGraph() throws Exception {
+        JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
+        JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
+        JenaIRI ex3 = jena.createIRI("http://example.com/ex3");
+        JenaLiteral lit = jena.createLiteral("Hello");
+        
+        JenaGeneralizedQuadLike t = jena.createGeneralizedQuad(ex1, ex2, ex3, lit);
+        assertEquals(ex1, t.getSubject()); 
+        assertEquals(ex2, t.getPredicate());
+        assertEquals(ex3, t.getObject());
+        assertTrue(t.getGraphName().isPresent());
+        assertEquals(lit, t.getGraphName().get());
+        assertTrue(t.asJenaQuad().getGraph().isLiteral());
+    }
+    
+    
+}

--- a/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFQuadTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFQuadTest.java
@@ -17,9 +17,12 @@
  */
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.rdf.api.BlankNode;
+import org.apache.jena.sparql.core.Quad;
 import org.junit.Test;
 
 public class GeneralizedRDFQuadTest {
@@ -33,11 +36,12 @@ public class GeneralizedRDFQuadTest {
         JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
         JenaIRI ex3 = jena.createIRI("http://example.com/ex3");
         
-        JenaGeneralizedQuadLike t = jena.createGeneralizedQuad(ex1, b1, ex2, ex3);
-        assertEquals(ex1, t.getSubject());
-        assertEquals(ex2, t.getObject());
-        assertEquals(b1, t.getPredicate()); // it's a bnode!
-        assertTrue(t.asJenaQuad().getPredicate().isBlank());
+        JenaGeneralizedQuadLike q = jena.createGeneralizedQuad(ex1, b1, ex2, ex3);
+        assertEquals(ex1, q.getSubject());
+        assertEquals(ex2, q.getObject());
+        assertEquals(b1, q.getPredicate()); // it's a bnode!
+        assertEquals(ex3, q.getGraphName().get());
+        assertTrue(q.asJenaQuad().getPredicate().isBlank());
     }
 
     @Test
@@ -47,11 +51,12 @@ public class GeneralizedRDFQuadTest {
         JenaIRI ex3 = jena.createIRI("http://example.com/ex3");
         JenaLiteral lit = jena.createLiteral("Hello");
         
-        JenaGeneralizedQuadLike t = jena.createGeneralizedQuad(ex1, lit, ex2, ex3);
-        assertEquals(ex1, t.getSubject());
-        assertEquals(ex2, t.getObject());
-        assertEquals(lit, t.getPredicate()); // it's a literal!
-        assertTrue(t.asJenaQuad().getPredicate().isLiteral());
+        JenaGeneralizedQuadLike q = jena.createGeneralizedQuad(ex1, lit, ex2, ex3);
+        assertEquals(ex1, q.getSubject());
+        assertEquals(ex2, q.getObject());
+        assertEquals(lit, q.getPredicate()); // it's a literal!
+        assertEquals(ex3, q.getGraphName().get());
+        assertTrue(q.asJenaQuad().getPredicate().isLiteral());
     }
 
 
@@ -62,14 +67,32 @@ public class GeneralizedRDFQuadTest {
         JenaIRI ex3 = jena.createIRI("http://example.com/ex3");
         JenaLiteral lit = jena.createLiteral("Hello");
         
-        JenaGeneralizedQuadLike t = jena.createGeneralizedQuad(lit, ex1, ex2, ex3);
-        assertEquals(lit, t.getSubject()); // it's a literal!
-        assertEquals(ex1, t.getPredicate());
-        assertEquals(ex2, t.getObject());
-        assertTrue(t.asJenaQuad().getSubject().isLiteral());
+        JenaGeneralizedQuadLike q = jena.createGeneralizedQuad(lit, ex1, ex2, ex3);
+        assertEquals(lit, q.getSubject()); // it's a literal!
+        assertEquals(ex1, q.getPredicate());
+        assertEquals(ex2, q.getObject());
+        assertEquals(ex3, q.getGraphName().get());
+        assertTrue(q.asJenaQuad().getSubject().isLiteral());
     }
     
+    @Test
+    public void literalSubjectDefaultGraphGen() throws Exception {
+        JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
+        JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
+        // No need to cast to JenaIRI
+        JenaRDFTerm defG = jena.asRDFTerm(Quad.defaultGraphNodeGenerated); 
+        JenaLiteral lit = jena.createLiteral("Hello");
+        
+        JenaGeneralizedQuadLike q = jena.createGeneralizedQuad(lit, ex1, ex2, defG);
+        assertEquals(lit, q.getSubject()); // it's a literal!
+        assertEquals(ex1, q.getPredicate());
+        assertEquals(ex2, q.getObject());
+        assertTrue(q.asJenaQuad().getSubject().isLiteral());
+        assertFalse(q.getGraphName().isPresent());
+        assertTrue(q.asJenaQuad().isDefaultGraph());
+    }
 
+    
     @Test
     public void literalGraph() throws Exception {
         JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
@@ -77,13 +100,12 @@ public class GeneralizedRDFQuadTest {
         JenaIRI ex3 = jena.createIRI("http://example.com/ex3");
         JenaLiteral lit = jena.createLiteral("Hello");
         
-        JenaGeneralizedQuadLike t = jena.createGeneralizedQuad(ex1, ex2, ex3, lit);
-        assertEquals(ex1, t.getSubject()); 
-        assertEquals(ex2, t.getPredicate());
-        assertEquals(ex3, t.getObject());
-        assertTrue(t.getGraphName().isPresent());
-        assertEquals(lit, t.getGraphName().get());
-        assertTrue(t.asJenaQuad().getGraph().isLiteral());
+        JenaGeneralizedQuadLike q = jena.createGeneralizedQuad(ex1, ex2, ex3, lit);
+        assertEquals(ex1, q.getSubject()); 
+        assertEquals(ex2, q.getPredicate());
+        assertEquals(ex3, q.getObject());
+        assertEquals(lit, q.getGraphName().get()); // it's a literal!
+        assertTrue(q.asJenaQuad().getGraph().isLiteral());
     }
     
     

--- a/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFTripleTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFTripleTest.java
@@ -17,9 +17,13 @@
  */
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.rdf.api.BlankNode;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
 import org.junit.Test;
 
 public class GeneralizedRDFTripleTest {
@@ -66,7 +70,16 @@ public class GeneralizedRDFTripleTest {
         assertTrue(t.asJenaTriple().getSubject().isLiteral());
     }
     
-    
-
+    @Test
+    public void asGeneralizedTriple() throws Exception {
+        Node s = NodeFactory.createLiteral("Hello");
+        Node p = NodeFactory.createBlankNode();
+        Node o = NodeFactory.createURI("http://example.com/ex");
+        Triple jt = Triple.create(s, p, o);
+        JenaTripleLike t = jena.asGeneralizedTriple(jt);
+        assertEquals(jena.createLiteral("Hello"), t.getSubject());
+        assertEquals(jena.asRDFTerm(p), t.getPredicate());
+        assertEquals(jena.createIRI("http://example.com/ex"), t.getObject());
+    }
     
 }

--- a/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFTripleTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFTripleTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.rdf.jena;
+
+import static org.junit.Assert.*;
+
+import org.apache.commons.rdf.api.BlankNode;
+import org.junit.Test;
+
+public class GeneralizedRDFTripleTest {
+
+    private JenaRDF jena = new JenaRDF();
+    
+    @Test
+    public void bnodeProperty() throws Exception {
+        BlankNode b1 = jena.createBlankNode("b1");
+        JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
+        JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
+        
+        JenaGeneralizedTripleLike t = jena.createGeneralizedTriple(ex1, b1, ex2);
+        assertEquals(ex1, t.getSubject());
+        assertEquals(ex2, t.getObject());
+        assertEquals(b1, t.getPredicate()); // it's a bnode!
+        assertTrue(t.asJenaTriple().getPredicate().isBlank());
+    }
+
+    @Test
+    public void literalPredicate() throws Exception {
+        JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
+        JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
+        JenaLiteral lit = jena.createLiteral("Hello");
+        
+        JenaGeneralizedTripleLike t = jena.createGeneralizedTriple(ex1, lit, ex2);
+        assertEquals(ex1, t.getSubject());
+        assertEquals(ex2, t.getObject());
+        assertEquals(lit, t.getPredicate()); // it's a literal!
+        assertTrue(t.asJenaTriple().getPredicate().isLiteral());
+    }
+
+
+    @Test
+    public void literalSubject() throws Exception {
+        JenaIRI ex1 = jena.createIRI("http://example.com/ex1");
+        JenaIRI ex2 = jena.createIRI("http://example.com/ex2");
+        JenaLiteral lit = jena.createLiteral("Hello");
+        
+        JenaGeneralizedTripleLike t = jena.createGeneralizedTriple(lit, ex1, ex2);
+        assertEquals(lit, t.getSubject()); // it's a literal!
+        assertEquals(ex1, t.getPredicate());
+        assertEquals(ex2, t.getObject());
+        assertTrue(t.asJenaTriple().getSubject().isLiteral());
+    }
+    
+    
+
+    
+}

--- a/jena/src/test/java/org/apache/commons/rdf/jena/JenaRDFTest.java
+++ b/jena/src/test/java/org/apache/commons/rdf/jena/JenaRDFTest.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.commons.rdf.jena;
 
 import org.apache.commons.rdf.api.AbstractRDFTest;


### PR DESCRIPTION
This fixes [COMMONSRDF-55](https://issues.apache.org/jira/browse/COMMONSRDF-55) by adding special testing of Jena's `urn:x-arq:DefaultGraph` and friends when creating a Quad.

It also fixes a NullPointerException as previously we wrongly  did `Quad.create(null, s,p,o)` with Jena, but `null` is not a valid graph name - `Quad.defaultGraphIRI` should be used instead.

Note that I did not hard-code `urn:x-arq:DefaultGraph` but use `IRI.equals()` against `Quad.defaultGraphIRI` and `Quad.defaultGraphNodeGenerated`.