### PR TITLE
Minor documentation updates

### DIFF
--- a/api/src/main/java/org/apache/commons/rdf/api/Dataset.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Dataset.java
@@ -23,9 +23,9 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * An <a href="http://www.w3.org/TR/rdf11-concepts/#section-rdf-dataset"> RDF
- * 1.1 dataset</a>, a set of RDF quads, as defined by
- * <a href="http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts and Abstract
+ * An <a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset">RDF
+ * 1.1 Dataset</a>, a set of RDF quads, as defined by
+ * <a href="http://www.w3.org/TR/rdf11-concepts/#section-rdf-dataset">RDF-1.1 Concepts and Abstract
  * Syntax</a>, a W3C Recommendation published on 25 February 2014.
  * 
  * @since 0.3.0-incubating

--- a/api/src/main/java/org/apache/commons/rdf/api/IRI.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/IRI.java
@@ -19,7 +19,7 @@ package org.apache.commons.rdf.api;
 
 /**
  * An <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-iri" >RDF-1.1 IRI</a>,
- * as defined by <a href= "http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1
+ * as defined by <a href= "http://www.w3.org/TR/rdf11-concepts/#section-IRIs" >RDF-1.1
  * Concepts and Abstract Syntax</a>, a W3C Recommendation published on 25
  * February 2014.
  * 

--- a/api/src/main/java/org/apache/commons/rdf/api/Literal.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Literal.java
@@ -23,10 +23,11 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A RDF-1.1 Literal, as defined by
+ * An <a href= "https://www.w3.org/TR/rdf11-concepts/#dfn-literal"
+ * >RDF-1.1 Literal</a>, as defined by
  * <a href= "http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal"
  * >RDF-1.1 Concepts and Abstract Syntax</a>, a W3C Recommendation published on
- * 25 February 2014
+ * 25 February 2014.
  * 
  * @see RDF#createLiteral(String)
  * @see RDF#createLiteral(String, IRI)

--- a/api/src/main/java/org/apache/commons/rdf/api/Triple.java
+++ b/api/src/main/java/org/apache/commons/rdf/api/Triple.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * An <a href= "http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple" >RDF-1.1
  * Triple</a>, as defined by
- * <a href= "http://www.w3.org/TR/rdf11-concepts/" >RDF-1.1 Concepts and
+ * <a href= "http://www.w3.org/TR/rdf11-concepts/#section-triples" >RDF-1.1 Concepts and
  * Abstract Syntax</a>, a W3C Recommendation published on 25 February 2014.
  * <p>
  * A <code>Triple</code> object in Commons RDF is considered


### PR DESCRIPTION
As can be seen on [this javadoc page](
https://commons.apache.org/proper/commons-rdf/apidocs/org/apache/commons/rdf/api/package-summary.html), some of the documentation and links to the W3C specification are formatted inconsistently.

This makes some changes to the documentation links so that they are consistent in how
they refer to the W3C specification.