### PR TITLE
COMMONSRDF-62 : Ignore japicmp by default while version is 0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,22 +450,21 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
-          <plugin>
-        <!-- Check if we broke compatibibility against previous release -->
-        <groupId>com.github.siom79.japicmp</groupId>
-        <artifactId>japicmp-maven-plugin</artifactId>
-        <version>${commons.japicmp.version}</version>
-        <configuration>
-          <parameter>
-            <!-- Tell japicmp about the -incubator suffix for 0.3.0 -->
-            <oldVersionPattern>\d+\.\d+\.\d+\-incubating</oldVersionPattern>
-            <!-- japicmp requires "mvn package site" - below means "mvn
-             site" still works (but without japicmp report) -->
-        <ignoreMissingNewVersion>true</ignoreMissingNewVersion>
-          </parameter>
-        </configuration>
-          </plugin>
-
+                <plugin>
+                    <!-- Check if we broke compatibibility against previous release -->
+                    <groupId>com.github.siom79.japicmp</groupId>
+                    <artifactId>japicmp-maven-plugin</artifactId>
+                    <version>${commons.japicmp.version}</version>
+                    <configuration>
+                        <parameter>
+                            <!-- Tell japicmp about the -incubator suffix for 0.3.0 -->
+                            <oldVersionPattern>\d+\.\d+\.\d+\-incubating</oldVersionPattern>
+                            <!-- japicmp requires "mvn package site" - below means "mvn
+                                 site" still works (but without japicmp report) -->
+                            <ignoreMissingNewVersion>true</ignoreMissingNewVersion>
+                        </parameter>
+                    </configuration>
+                </plugin>
                 <!--
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -581,6 +580,16 @@
     </reporting>
 
     <profiles>
+        <profile>
+            <id>ignore-japicmp</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <!-- COMMONSRDF-62 : JAPICMP does not handle 0.x release boundaries as defined in Semantic Versioning -->
+                <commons.japicmp.breakBuildOnBinaryIncompatibleModifications>false</commons.japicmp.breakBuildOnBinaryIncompatibleModifications>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
         <!-- extends the release profile from commons -->


### PR DESCRIPTION
japicmp is activated by commons-parent profile with it set to break the build on any incompatibilities. In order to have it still run by default, but not break the build, an activeByDefault=true profile is added, which will be switched off by activating any other profiles explicitly, including the release profile, but which allows development of 0.x without interruption from japicmp.

This is either an alternative, or in addition to, https://github.com/apache/commons-rdf/pull/38

The core reason is that japicmp is not recognising 0.3 -> 0.4 as a major version jump, in Semantic Versioning terms. It is treating that as a minor version jump, where the API incompatibilities still apply.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>