### PR TITLE
COMMONSRDF-67: Make commons-rdf buildable on JDK 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <commons.jira.id>COMMONSRDF</commons.jira.id>
         <commons.jira.pid>12316620</commons.jira.pid>
         <commons.site.path>rdf</commons.site.path>
+        <commons.jacoco.version>0.7.9</commons.jacoco.version>
 	    <commons.scmPubUrl>https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-rdf/</commons.scmPubUrl>
         <!--
         <commons.scmPubCheckoutDirectory>${project.build.directory}/site-content</commons.scmPubCheckoutDirectory>
@@ -473,6 +474,24 @@
                             <ignoreMissingNewVersion>true</ignoreMissingNewVersion>
                         </parameter>
                     </configuration>
+                    <dependencies>
+                      <dependency>
+                        <!-- the current version of japicmp on JDK 9 requires the following javaee libraries -->
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.0</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>activation</artifactId>
+                        <version>1.1.1</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                        <version>2.3.0</version>
+                      </dependency>
+                    </dependencies>
                 </plugin>
                 <!--
                 <plugin>


### PR DESCRIPTION
The current japicmp maven plugin requires a number of javaee
libraries that are not available on JDK 9. Until this is fixed
in the upstream project, this adds the required dependencies
for the plugin so that commons-rdf can be built on JDK 9.

The jacoco tool version is also updated to support Java 9.