### PR TITLE
update to jena 4.10.0 (without osgi)

### DIFF
--- a/commons-rdf-integration-tests/src/test/resources/alice-cached.jsonld
+++ b/commons-rdf-integration-tests/src/test/resources/alice-cached.jsonld
@@ -1,8 +1,8 @@
 { "http://purl.org/dc/terms/license" :
    "Licensed to the Apache Software Foundation (ASF) under one or more\n contributor license agreements.  See the NOTICE file distributed with\n this work for additional information regarding copyright ownership.\n The ASF licenses this file to You under the Apache License, Version 2.0\n (the \"License\"); you may not use this file except in compliance with\n the License.  You may obtain a copy of the License at\n \n http://www.apache.org/licenses/LICENSE-2.0\n \n Unless required by applicable law or agreed to in writing, software\n distributed under the License is distributed on an \"AS IS\" BASIS,\n WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n See the License for the specific language governing permissions and\n limitations under the License.\n",
   
-  "@context": "http://example.com/context",
-  "@id": "ex:Alice",
+  "@context": "https://schema.org/docs/jsonldcontext.jsonld",
+  "@id": "http://example.com/Alice",
   "@type": "Person",
   "name": "Alice W. Land"
 }

--- a/commons-rdf-jena/pom.xml
+++ b/commons-rdf-jena/pom.xml
@@ -53,24 +53,26 @@
 		</dependency>
 		<!-- Uncomment below and disable jena-osgi to access the regular non-osgi 
 			 Jena dependencies (e.g. for debugging) -->
-		<!-- 
-	
 		<dependency>
 			<groupId>org.apache.jena</groupId>
 			<artifactId>apache-jena-libs</artifactId>
 			<version>${jena.version}</version>
 			<type>pom</type>
-			<scope>optional</scope>
 		</dependency>
-				--> 
 
 		<!-- As commons-rdf-jena is an OSGi bundle, we'll use the Jena OSGi bundle -->
-		<dependency>
-			<groupId>org.apache.jena</groupId>
-			<artifactId>jena-osgi</artifactId>
-			<version>${jena.version}</version>
-		</dependency>
-
+<!--		<dependency>-->
+<!--			<groupId>org.apache.jena</groupId>-->
+<!--			<artifactId>jena-osgi</artifactId>-->
+<!--			<version>${jena.version}</version>-->
+<!--		</dependency>-->
+<!--
+### Apache Jena OSGi
+The last release of apache-jena-osgi source was with Jena 4.2.0 on 2021-09-16.
+The last release of the OSGi binary artifacts was with Jena 4.1.0 2021-06-04.
+Source is available from git with tag "jena-4.2.0".
+The commit retiring apache-jena-osgi is 79a477c00e.
+-->
 		<!-- Additional bundles needed by jena-osgi -->
 		<dependency>
 			<groupId>org.apache.servicemix.bundles</groupId>

--- a/commons-rdf-jena/src/main/java/org/apache/commons/rdf/jena/JenaRDF.java
+++ b/commons-rdf-jena/src/main/java/org/apache/commons/rdf/jena/JenaRDF.java
@@ -580,7 +580,7 @@ public final class JenaRDF implements RDF {
      * @return Matched {@link RDFSyntax}, otherwise {@link Optional#empty()}
      */
     public Optional<RDFSyntax> asRDFSyntax(final Lang lang) {
-        return RDFSyntax.byMediaType(lang.getContentType().getContentType());
+        return RDFSyntax.byMediaType(lang.getContentType().getContentTypeStr());
     }
 
     /**

--- a/commons-rdf-jena/src/main/java/org/apache/commons/rdf/jena/impl/InternalJenaFactory.java
+++ b/commons-rdf-jena/src/main/java/org/apache/commons/rdf/jena/impl/InternalJenaFactory.java
@@ -43,7 +43,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.graph.GraphFactory;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 
 /**
  * Constructs Jena implementations of Commons RDF.

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 	          is cross-compatible -->
         <jsonldjava.version>0.13.4</jsonldjava.version>
         <rdf4j.version>3.7.7</rdf4j.version>
-        <jena.version>3.5.0</jena.version>
+        <jena.version>4.10.0</jena.version>
         <!--  NOTE: dexx and xerces versions should match 
         the versions marked as <optional> in jena-osgi pom
          -->


### PR DESCRIPTION
Hi there,
i think I would like to use commons-rdf, but not with the old Jena version. So here is a PR for a new version. I have no idea about osgi and jena doesn't seem to support it anymore. so I just used the non osgi dependency.