### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/AbstractBlankNodeTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/AbstractBlankNodeTest.java
@@ -17,10 +17,10 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for the BlankNode interface.

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/AbstractGraphTest.java
@@ -17,11 +17,14 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -33,9 +36,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Graph implementation
@@ -92,7 +94,7 @@ public abstract class AbstractGraphTest {
         // thread-safe
 
         try (Stream<? extends Triple> stream = source.stream()) {
-            stream.unordered().sequential().forEach(t -> target.add(t));
+            stream.unordered().sequential().forEach(target::add);
         }
     }
 
@@ -153,7 +155,7 @@ public abstract class AbstractGraphTest {
         return g2;
     }
 
-    @Before
+    @BeforeEach
     public void createGraphAndAdd() {
         factory = createFactory();
         graph = factory.createGraph();
@@ -246,10 +248,10 @@ public abstract class AbstractGraphTest {
     }
 
     private void notEquals(final BlankNodeOrIRI node1, final BlankNodeOrIRI node2) {
-        assertFalse(node1.equals(node2));
+        assertNotEquals(node1, node2);
         // in which case we should be able to assume
         // (as they are in the same graph)
-        assertFalse(node1.ntriplesString().equals(node2.ntriplesString()));
+        assertNotEquals(node1.ntriplesString(), node2.ntriplesString());
     }
 
     @Test
@@ -315,7 +317,7 @@ public abstract class AbstractGraphTest {
             assertFalse(g3.contains(b2Bob, hasChild, null));
             assertFalse(g3.contains(b1Charlie, hasChild, null));
         } catch (final UnsupportedOperationException ex) {
-            Assume.assumeNoException(ex);
+            assumeFalse(true);
         }
     }
 
@@ -336,7 +338,7 @@ public abstract class AbstractGraphTest {
 
         try (Stream<? extends Triple> stream = graph.stream()) {
             final Optional<? extends Triple> first = stream.skip(4).findFirst();
-            Assume.assumeTrue(first.isPresent());
+            assumeTrue(first.isPresent());
             final Triple existingTriple = first.get();
             assertTrue(graph.contains(existingTriple));
         }
@@ -404,7 +406,7 @@ public abstract class AbstractGraphTest {
             // If the below assertion fails, then the Turkish
             // locale no longer have this peculiarity that
             // we want to test.
-            Assume.assumeFalse("FI".toLowerCase().equals("fi"));
+            assumeFalse("FI".toLowerCase().equals("fi"));
 
             // Below is pretty much the same as in
             // containsLanguageTagsCaseInsensitive()
@@ -452,7 +454,7 @@ public abstract class AbstractGraphTest {
         }
 
         // Check exact count
-        Assume.assumeNotNull(bnode1, bnode2, aliceName, bobName, secretClubName, companyName, bobNameTriple);
+        assumeTrue(bnode1 != null && bnode2 != null && aliceName != null && bobName != null && secretClubName != null && companyName != null && bobNameTriple != null);
         assertEquals(8, tripleCount);
     }
 
@@ -462,15 +464,15 @@ public abstract class AbstractGraphTest {
         try (Stream<? extends Triple> stream = graph.stream(alice, null, null)) {
             final long aliceCount = stream.count();
             assertTrue(aliceCount > 0);
-            Assume.assumeNotNull(aliceName);
+            assumeTrue(aliceName != null);
             assertEquals(3, aliceCount);
         }
 
-        Assume.assumeNotNull(bnode1, bnode2, bobName, companyName, secretClubName);
+        assumeTrue(bnode1 != null && bnode2 != null && bobName != null && companyName != null && secretClubName != null);
         try (Stream<? extends Triple> stream = graph.stream(null, name, null)) {
             assertEquals(4, stream.count());
         }
-        Assume.assumeNotNull(bnode1);
+        assumeTrue(bnode1 != null);
         try (Stream<? extends Triple> stream = graph.stream(null, member, null)) {
             assertEquals(3, stream.count());
         }
@@ -479,7 +481,7 @@ public abstract class AbstractGraphTest {
     @Test
     public void testIterate() throws Exception {
 
-        Assume.assumeFalse(graph.isEmpty());
+        assumeFalse(graph.isEmpty());
 
         final List<Triple> triples = new ArrayList<>();
         for (final Triple t : graph.iterate()) {
@@ -552,7 +554,7 @@ public abstract class AbstractGraphTest {
         Triple otherTriple;
         try (Stream<? extends Triple> stream = graph.stream()) {
             final Optional<? extends Triple> anyTriple = stream.findAny();
-            Assume.assumeTrue(anyTriple.isPresent());
+            assumeTrue(anyTriple.isPresent());
             otherTriple = anyTriple.get();
         }
 
@@ -599,7 +601,7 @@ public abstract class AbstractGraphTest {
     @Test
     public void testSize() throws Exception {
         assertFalse(graph.isEmpty());
-        Assume.assumeNotNull(bnode1, bnode2, aliceName, bobName, secretClubName, companyName, bobNameTriple);
+        assumeTrue(bnode1 != null && bnode2 != null && aliceName != null && bobName != null && secretClubName != null && companyName != null && bobNameTriple != null);
         // Can only reliably predict size if we could create all triples
         assertEquals(8, graph.size());
     }
@@ -648,7 +650,7 @@ public abstract class AbstractGraphTest {
      */
     @Test
     public void testWhyJavaStreamsMightNotTakeOverFromSparql() throws Exception {
-        Assume.assumeNotNull(bnode1, bnode2, secretClubName);
+        assumeTrue(bnode1 != null && bnode2 != null && secretClubName != null);
         // Find a secret organizations
         try (Stream<? extends Triple> stream = graph.stream(null, knows, null)) {
             assertEquals("\"The Secret Club\"",

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/AbstractRDFTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/AbstractRDFTest.java
@@ -17,18 +17,19 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test RDF implementation (and thus its RDFTerm implementations)
@@ -59,7 +60,7 @@ public abstract class AbstractRDFTest {
      */
     protected abstract RDF createFactory();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         factory = createFactory();
     }
@@ -69,8 +70,9 @@ public abstract class AbstractRDFTest {
         final BlankNode bnode = factory.createBlankNode();
 
         final BlankNode bnode2 = factory.createBlankNode();
-        assertNotEquals("Second blank node has not got a unique internal identifier", bnode.uniqueReference(),
-                bnode2.uniqueReference());
+        assertNotEquals(bnode.uniqueReference(),
+                bnode2.uniqueReference(),
+                "Second blank node has not got a unique internal identifier");
     }
 
     @Test
@@ -128,12 +130,12 @@ public abstract class AbstractRDFTest {
     public void testCreateGraph() throws Exception {
         try (final Graph graph = factory.createGraph(); final Graph graph2 = factory.createGraph()) {
 
-            assertEquals("Graph was not empty", 0, graph.size());
+            assertEquals(0, graph.size(), "Graph was not empty");
             graph.add(factory.createBlankNode(), factory.createIRI("http://example.com/"), factory.createBlankNode());
 
             assertNotSame(graph, graph2);
-            assertEquals("Graph was empty after adding", 1, graph.size());
-            assertEquals("New graph was not empty", 0, graph2.size());
+            assertEquals(1, graph.size(), "Graph was empty after adding");
+            assertEquals(0, graph2.size(), "New graph was not empty");
         }
     }
 
@@ -256,7 +258,7 @@ public abstract class AbstractRDFTest {
             // If the below assertion fails, then the Turkish
             // locale no longer have this peculiarity that
             // we want to test.
-            Assume.assumeFalse("FI".toLowerCase().equals("fi"));
+            assumeFalse("FI".toLowerCase().equals("fi"));
 
             final Literal mixed = factory.createLiteral("moi", "fI");
             final Literal lower = factory.createLiteral("moi", "fi");
@@ -418,22 +420,26 @@ public abstract class AbstractRDFTest {
         assertEquals(Objects.hash(iri, iri, iri), triple.hashCode());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidIRI() throws Exception {
-        factory.createIRI("<no_brackets>");
+        assertThrows(IllegalArgumentException.class, () ->
+            factory.createIRI("<no_brackets>"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidLiteralLang() throws Exception {
-        factory.createLiteral("Example", "with space");
+        assertThrows(IllegalArgumentException.class, () ->
+            factory.createLiteral("Example", "with space"));
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void testInvalidTriplePredicate() {
-        final BlankNode subject = factory.createBlankNode("b1");
-        final BlankNode predicate = factory.createBlankNode("b2");
-        final BlankNode object = factory.createBlankNode("b3");
-        factory.createTriple(subject, (IRI) predicate, object);
+        assertThrows(Exception.class, () -> {
+            final BlankNode subject = factory.createBlankNode("b1");
+            final BlankNode predicate = factory.createBlankNode("b2");
+            final BlankNode object = factory.createBlankNode("b3");
+            factory.createTriple(subject, (IRI) predicate, object);
+        });
     }
 
     @Test

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DefaultDatasetTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DefaultDatasetTest.java
@@ -17,11 +17,11 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultDatasetTest {
 
@@ -37,7 +37,7 @@ public class DefaultDatasetTest {
         assertFalse(dataset.streamCalled);
         assertFalse(dataset.filteredStreamCalled);
         for (final Quad t : dataset.iterate(null, null, new DummyIRI(2), null)) {
-            assertEquals(t, new DummyQuad());
+            assertEquals(new DummyQuad(), t);
         }
         assertTrue(dataset.filteredStreamCalled);
         assertFalse(dataset.streamCalled);
@@ -48,7 +48,7 @@ public class DefaultDatasetTest {
         assertFalse(dataset.streamCalled);
         assertFalse(dataset.filteredStreamCalled);
         for (final Quad t : dataset.iterate()) {
-            assertEquals(t, new DummyQuad());
+            assertEquals(new DummyQuad(), t);
         }
         assertTrue(dataset.streamCalled);
         assertFalse(dataset.filteredStreamCalled);

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DefaultGraphTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DefaultGraphTest.java
@@ -17,11 +17,11 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultGraphTest {
 
@@ -37,7 +37,7 @@ public class DefaultGraphTest {
         assertFalse(graph.streamCalled);
         assertFalse(graph.filteredStreamCalled);
         for (final Triple t : graph.iterate(null, new DummyIRI(2), null)) {
-            assertEquals(t, new DummyTriple());
+            assertEquals(new DummyTriple(), t);
         }
         assertTrue(graph.filteredStreamCalled);
         assertFalse(graph.streamCalled);
@@ -70,7 +70,7 @@ public class DefaultGraphTest {
         assertFalse(graph.streamCalled);
         assertFalse(graph.filteredStreamCalled);
         for (final Triple t : graph.iterate()) {
-            assertEquals(t, new DummyTriple());
+            assertEquals(new DummyTriple(), t);
         }
         assertTrue(graph.streamCalled);
         assertFalse(graph.filteredStreamCalled);

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DefaultQuadTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DefaultQuadTest.java
@@ -17,12 +17,12 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Objects;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultQuadTest {
     @Test
@@ -31,8 +31,8 @@ public class DefaultQuadTest {
         final Triple t = q.asTriple();
         assertEquals(t, t);
         assertNotEquals(t,  q);
-        assertEquals(t, new DummyTriple());
-        assertEquals(t, new DummyQuad().asTriple());
+        assertEquals(new DummyTriple(), t);
+        assertEquals(new DummyQuad().asTriple(), t);
 
         // FIXME: This would not catch if asTriple() accidentally mixed up s/p/o
         // as they are here all the same

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DefaultRDFTermFactoryTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DefaultRDFTermFactoryTest.java
@@ -17,7 +17,9 @@
  */
 package org.apache.commons.rdf.api;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that all {@link RDFTermFactory} default methods throw
@@ -28,36 +30,51 @@ public class DefaultRDFTermFactoryTest {
     // All methods in RDFTermFactory has a default implementation
     RDFTermFactory factory = new RDFTermFactory() {};
 
-    @Test(expected=UnsupportedOperationException.class)
+    @Test
     public void createBlankNode() throws Exception {
-        factory.createBlankNode();
+        assertThrows(UnsupportedOperationException.class, () ->
+            factory.createBlankNode());
     }
-    @Test(expected=UnsupportedOperationException.class)
+
+    @Test
     public void createBlankNodeName() throws Exception {
-        factory.createBlankNode("fred");
+        assertThrows(UnsupportedOperationException.class, () ->
+            factory.createBlankNode("fred"));
     }
-    @Test(expected=UnsupportedOperationException.class)
+
+    @Test
     public void createGraph() throws Exception {
-        factory.createGraph();
+        assertThrows(UnsupportedOperationException.class, () ->
+            factory.createGraph());
     }
-    @Test(expected=UnsupportedOperationException.class)
+
+    @Test
     public void createIRI() throws Exception {
-        factory.createIRI("http://example.com/");
+        assertThrows(UnsupportedOperationException.class, () ->
+            factory.createIRI("http://example.com/"));
     }
-    @Test(expected=UnsupportedOperationException.class)
+
+    @Test
     public void createLiteral() throws Exception {
-        factory.createLiteral("Alice");
+        assertThrows(UnsupportedOperationException.class, () ->
+            factory.createLiteral("Alice"));
     }
-    @Test(expected=UnsupportedOperationException.class)
+
+    @Test
     public void createLiteralLang() throws Exception {
-        factory.createLiteral("Alice", "en");
+        assertThrows(UnsupportedOperationException.class, () ->
+            factory.createLiteral("Alice", "en"));
     }
-    @Test(expected=UnsupportedOperationException.class)
+
+    @Test
     public void createLiteralTyped() throws Exception {
-        factory.createLiteral("Alice", new DummyIRI(0));
+        assertThrows(UnsupportedOperationException.class, () ->
+            factory.createLiteral("Alice", new DummyIRI(0)));
     }
-    @Test(expected=UnsupportedOperationException.class)
+
+    @Test
     public void createTriple() throws Exception {
-        factory.createTriple(new DummyIRI(1), new DummyIRI(2), new DummyIRI(3));
+        assertThrows(UnsupportedOperationException.class, () ->
+            factory.createTriple(new DummyIRI(1), new DummyIRI(2), new DummyIRI(3)));
     }
 }

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyDataset.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyDataset.java
@@ -17,7 +17,6 @@
  */
 package org.apache.commons.rdf.api;
 
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -93,7 +92,7 @@ final class DummyDataset implements Dataset {
     @Override
     public Stream<? extends Quad> stream() {
         streamCalled = true;
-        return Arrays.asList(new DummyQuad()).stream();
+        return Stream.of(new DummyQuad());
     }
 
     @Override

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyDatasetTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyDatasetTest.java
@@ -17,23 +17,27 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DummyDatasetTest {
     Dataset dataset = new DummyDataset();
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void clearNotSupported() throws Exception {
-        dataset.clear();
+        assertThrows(IllegalStateException.class, () ->
+            dataset.clear());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void remove() throws Exception {
-        dataset.remove(new DummyQuad());
+        assertThrows(IllegalStateException.class, () ->
+            dataset.remove(new DummyQuad()));
     }
 
     @Test
@@ -60,7 +64,7 @@ public class DummyDatasetTest {
 
     @Test
     public void testGetGraph() throws Exception {
-        assertTrue(dataset.getGraph() instanceof DummyGraph);
+        assertInstanceOf(DummyGraph.class, dataset.getGraph());
     }
 
     @Test
@@ -75,7 +79,7 @@ public class DummyDatasetTest {
 
     @Test
     public void testGetGraphNull() throws Exception {
-        assertTrue(dataset.getGraph(null).get() instanceof DummyGraph);
+        assertInstanceOf(DummyGraph.class, dataset.getGraph(null).get());
     }
 
     @Test

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyGraph.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyGraph.java
@@ -17,7 +17,6 @@
  */
 package org.apache.commons.rdf.api;
 
-import java.util.Arrays;
 import java.util.stream.Stream;
 
 final class DummyGraph implements Graph {
@@ -70,7 +69,7 @@ final class DummyGraph implements Graph {
     @Override
     public Stream<? extends Triple> stream() {
         streamCalled = true;
-        return Arrays.asList(new DummyTriple()).stream();
+        return Stream.of(new DummyTriple());
     }
 
     @Override

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyGraphTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyGraphTest.java
@@ -17,23 +17,26 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DummyGraphTest {
     Graph graph = new DummyGraph();
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void clearNotSupported() throws Exception {
-        graph.clear();
+        assertThrows(IllegalStateException.class, () ->
+            graph.clear());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void remove() throws Exception {
-        graph.remove(new DummyTriple());
+        assertThrows(IllegalStateException.class, () ->
+            graph.remove(new DummyTriple()));
     }
 
     @Test

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyIRITest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyIRITest.java
@@ -17,17 +17,17 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DummyIRITest {
     DummyIRI iri = new DummyIRI(1337);
 
     @Test
     public void testEquals() throws Exception {
-        assertEquals(iri, new DummyIRI(1337));
+        assertEquals(new DummyIRI(1337), iri);
     }
 
     @Test
@@ -47,7 +47,7 @@ public class DummyIRITest {
 
     @Test
     public void testNotEquals() throws Exception {
-        assertNotEquals(iri, new DummyIRI(1));
+        assertNotEquals(new DummyIRI(1), iri);
     }
 
     @Test

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyQuadTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyQuadTest.java
@@ -17,29 +17,31 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Objects;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DummyQuadTest {
     Quad quad = new DummyQuad();
 
     @Test
     public void testEquals() throws Exception {
-        assertEquals(quad, new DummyQuad());
+        assertEquals(new DummyQuad(), quad);
     }
 
     @Test
     public void testGetGraphName() throws Exception {
         assertFalse(quad.getGraphName().isPresent());
     }
+
     @Test
     public void testGetObject() throws Exception {
         assertEquals(3, ((DummyIRI) quad.getObject()).i);
     }
+
     @Test
     public void testGetPredicate() throws Exception {
         assertEquals(2, ((DummyIRI) quad.getPredicate()).i);

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyTripleTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/DummyTripleTest.java
@@ -17,23 +17,25 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Objects;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DummyTripleTest {
     Triple triple = new DummyTriple();
 
     @Test
     public void testEquals() throws Exception {
-        assertEquals(triple, new DummyTriple());
+        assertEquals(new DummyTriple(), triple);
     }
+
     @Test
     public void testGetObject() throws Exception {
         assertEquals(3, ((DummyIRI) triple.getObject()).i);
     }
+
     @Test
     public void testGetPredicate() throws Exception {
         assertEquals(2, ((DummyIRI) triple.getPredicate()).i);

--- a/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/RDFSyntaxTest.java
+++ b/commons-rdf-api/src/test/java/org/apache/commons/rdf/api/RDFSyntaxTest.java
@@ -17,12 +17,12 @@
  */
 package org.apache.commons.rdf.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RDFSyntaxTest {
 

--- a/commons-rdf-examples/src/example/IntroToRDFTest.java
+++ b/commons-rdf-examples/src/example/IntroToRDFTest.java
@@ -17,8 +17,7 @@
  */
 package example;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IntroToRDFTest {
 

--- a/commons-rdf-examples/src/example/UserGuideTest.java
+++ b/commons-rdf-examples/src/example/UserGuideTest.java
@@ -37,15 +37,15 @@ import org.apache.commons.rdf.api.Triple;
 import org.apache.commons.rdf.api.TripleLike;
 import org.apache.commons.rdf.simple.SimpleRDF;
 import org.apache.commons.rdf.simple.Types;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class UserGuideTest {
 
     private RDF factory;
 
-    @Before
-    public void factory() {
+    @BeforeAll
+    public static void factory() {
         factory = new SimpleRDF();
     }
 

--- a/commons-rdf-integration-tests/src/test/java/org/apache/commons/rdf/integrationtests/AllToAllTest.java
+++ b/commons-rdf-integration-tests/src/test/java/org/apache/commons/rdf/integrationtests/AllToAllTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.commons.rdf.integrationtests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,16 +36,12 @@ import org.apache.commons.rdf.jena.JenaRDF;
 import org.apache.commons.rdf.jsonldjava.JsonLdRDF;
 import org.apache.commons.rdf.rdf4j.RDF4J;
 import org.apache.commons.rdf.simple.SimpleRDF;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class AllToAllTest {
 
     @SuppressWarnings("rawtypes")
-    @Parameters(name = "{index}: {0}->{1}")
     public static Collection<Object[]> data() {
         final List<Class> factories = Arrays.asList(SimpleRDF.class, JenaRDF.class, RDF4J.class, JsonLdRDF.class);
         final Collection<Object[]> allToAll = new ArrayList<>();
@@ -58,15 +54,6 @@ public class AllToAllTest {
         }
         return allToAll;
     }
-    private final RDF nodeFactory;
-
-    private final RDF graphFactory;
-
-    public AllToAllTest(final Class<? extends RDF> from, final Class<? extends RDF> to)
-            throws ReflectiveOperationException {
-        this.nodeFactory = from.getConstructor().newInstance();
-        this.graphFactory = to.newInstance();
-    }
 
     /**
      * This test creates a {@link Graph} with the first {@link RDF},
@@ -76,8 +63,12 @@ public class AllToAllTest {
      * @throws Exception
      *             Just in case.
      */
-    @Test
-    public void testAddTermsFromOtherFactory() throws Exception {
+    @MethodSource("data")
+    @ParameterizedTest(name = "{index}: {0}->{1}")
+    public void testAddTermsFromOtherFactory(final Class<? extends RDF> from, final Class<? extends RDF> to) throws Exception {
+        RDF nodeFactory = from.getConstructor().newInstance();
+        RDF graphFactory = to.newInstance();
+
         try (final Graph g = graphFactory.createGraph()) {
             final BlankNode s = nodeFactory.createBlankNode();
             final IRI p = nodeFactory.createIRI("http://example.com/p");
@@ -117,15 +108,19 @@ public class AllToAllTest {
     }
 
     /**
-     * This is a variation of {@link #addTermsFromOtherFactory()}, but here
+     * This is a variation of {@link #testAddTermsFromOtherFactory(Class, Class)}, but here
      * {@link Triple} is created in the "foreign" nodeFactory before adding to
      * the graph.
      *
      * @throws Exception
      *             Just in case.
      */
-    @Test
-    public void testAddTriplesFromOtherFactory() throws Exception {
+    @MethodSource("data")
+    @ParameterizedTest(name = "{index}: {0}->{1}")
+    public void testAddTriplesFromOtherFactory(final Class<? extends RDF> from, final Class<? extends RDF> to) throws Exception {
+        RDF nodeFactory = from.getConstructor().newInstance();
+        RDF graphFactory = to.newInstance();
+
         try (final Graph g = graphFactory.createGraph()) {
             final BlankNode s = nodeFactory.createBlankNode();
             final IRI p = nodeFactory.createIRI("http://example.com/p");

--- a/commons-rdf-integration-tests/src/test/java/org/apache/commons/rdf/integrationtests/JSONLDParsingTest.java
+++ b/commons-rdf-integration-tests/src/test/java/org/apache/commons/rdf/integrationtests/JSONLDParsingTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.commons.rdf.integrationtests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -37,8 +37,8 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.core.JsonLdProcessor;
@@ -86,7 +86,7 @@ public class JSONLDParsingTest {
     /**
      * Pre-test that src/test/resources files are on the classpath
      */
-    @Before
+    @BeforeEach
     public void checkTestResources() throws Exception {
         aliceCached.openStream().close();
         aliceEmbedded.openStream().close();

--- a/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/DatasetJenaTest.java
+++ b/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/DatasetJenaTest.java
@@ -17,14 +17,14 @@
  */
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.rdf.api.AbstractDatasetTest;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Literal;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.simple.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DatasetJenaTest extends AbstractDatasetTest {
 

--- a/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/DefaultGraphInQuadTest.java
+++ b/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/DefaultGraphInQuadTest.java
@@ -17,16 +17,16 @@
  */
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.simple.SimpleRDF;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Quad;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * COMMONSRDF-55: Handling of

--- a/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFQuadTest.java
+++ b/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFQuadTest.java
@@ -17,16 +17,16 @@
  */
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.rdf.api.BlankNode;
 import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Quad;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeneralizedRDFQuadTest {
 

--- a/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFTripleTest.java
+++ b/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/GeneralizedRDFTripleTest.java
@@ -17,14 +17,14 @@
  */
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.rdf.api.BlankNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeneralizedRDFTripleTest {
 

--- a/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/JenaRDFTest.java
+++ b/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/JenaRDFTest.java
@@ -17,9 +17,9 @@
  */
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.rdf.api.AbstractRDFTest;
 import org.apache.commons.rdf.api.BlankNode;
@@ -34,7 +34,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JenaRDFTest extends AbstractRDFTest {
 
@@ -48,7 +48,7 @@ public class JenaRDFTest extends AbstractRDFTest {
         final DatasetGraph dsg = DatasetGraphFactory.create();
         final JenaDataset dataset = createFactory().asDataset(dsg);
         final DatasetGraph roundTrippedDSG = createFactory().asJenaDatasetGraph(dataset);
-        assertSame("Should have gotten the same DatasetGraph object from a round trip!", dsg, roundTrippedDSG);
+        assertSame(dsg, roundTrippedDSG, "Should have gotten the same DatasetGraph object from a round trip!");
     }
 
     @Test
@@ -63,9 +63,9 @@ public class JenaRDFTest extends AbstractRDFTest {
         ds.add(quad);
         final JenaRDF jenaFactory = createFactory();
         final org.apache.jena.query.Dataset jenaDS = jenaFactory.asJenaDataset(ds);
-        assertEquals("Should have found one named graph!", 1, jenaDS.asDatasetGraph().size());
+        assertEquals(1, jenaDS.asDatasetGraph().size(), "Should have found one named graph!");
         final Model namedModel = jenaDS.getNamedModel(graph.getIRIString());
-        assertEquals("Should have found one triple in named graph!", 1, namedModel.size());
+        assertEquals(1, namedModel.size(), "Should have found one triple in named graph!");
         final Statement statement = namedModel.listStatements().next();
         final Resource jenaSubject = statement.getSubject();
         final Property jenaPredicate = statement.getPredicate();

--- a/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/JenaServiceLoaderTest.java
+++ b/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/JenaServiceLoaderTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ServiceLoader;
 
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JenaServiceLoaderTest {
 

--- a/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/TestJenaGraphToCommonsRDFGraph.java
+++ b/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/TestJenaGraphToCommonsRDFGraph.java
@@ -18,8 +18,9 @@
 
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,23 +36,23 @@ import org.apache.commons.rdf.simple.Types;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.graph.GraphFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Adapt a Jena Graph after parsing data into it */
 public class TestJenaGraphToCommonsRDFGraph {
     private static final boolean DEBUG = false;
     private Path turtleFile;
 
-    @After
+    @AfterEach
     public void deletePath() throws IOException {
         if (turtleFile != null) {
             Files.deleteIfExists(turtleFile);
         }
     }
 
-    @Before
+    @BeforeEach
     public void preparePath() throws IOException {
         turtleFile = Files.createTempFile("commonsrdf", "test.ttl");
         Files.copy(getClass().getResourceAsStream("/D.ttl"), turtleFile, StandardCopyOption.REPLACE_EXISTING);
@@ -77,13 +78,13 @@ public class TestJenaGraphToCommonsRDFGraph {
             final JenaIRI p1 = factory.createIRI("http://example.com/p1");
             // Let's look up the BlankNode
             final BlankNodeOrIRI bnode1 = graph.stream(null, p1, null).findFirst().map(Triple::getSubject).get();
-            assertTrue(bnode1 instanceof BlankNode);
+            assertInstanceOf(BlankNode.class, bnode1);
 
             // Verify we can use BlankNode in query again
             final RDFTerm obj = graph.stream(bnode1, p1, null).findFirst().map(Triple::getObject).get();
 
             // Let's look up also that nested blank node
-            assertTrue(obj instanceof BlankNode);
+            assertInstanceOf(BlankNode.class, obj);
             final BlankNode bnode2 = (BlankNode) obj;
 
             final JenaIRI q = factory.createIRI("http://example.com/q");

--- a/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/TestRDFParserBuilder.java
+++ b/commons-rdf-jena/src/test/java/org/apache/commons/rdf/jena/TestRDFParserBuilder.java
@@ -18,7 +18,7 @@
 
 package org.apache.commons.rdf.jena;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,22 +31,22 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.RDFSyntax;
 import org.apache.commons.rdf.experimental.RDFParser.ParseResult;
 import org.apache.commons.rdf.jena.experimental.JenaRDFParser;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestRDFParserBuilder {
 
     private Path turtleFile;
 
-    @After
+    @AfterEach
     public void deletePath() throws IOException {
         if (turtleFile != null) {
             Files.deleteIfExists(turtleFile);
         }
     }
 
-    @Before
+    @BeforeEach
     public void preparePath() throws IOException {
         turtleFile = Files.createTempFile("commonsrdf", "test.ttl");
         Files.copy(getClass().getResourceAsStream("/D.ttl"), turtleFile, StandardCopyOption.REPLACE_EXISTING);

--- a/commons-rdf-jsonld-java/src/test/java/org/apache/commons/rdf/jsonldjava/JsonLdComparisonTest.java
+++ b/commons-rdf-jsonld-java/src/test/java/org/apache/commons/rdf/jsonldjava/JsonLdComparisonTest.java
@@ -17,15 +17,15 @@
  */
 package org.apache.commons.rdf.jsonldjava;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 
 import org.apache.commons.rdf.simple.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * COMMONSRDF-56: Test Literal comparisons with JSONLD-Java

--- a/commons-rdf-jsonld-java/src/test/java/org/apache/commons/rdf/jsonldjava/JsonLdParserBuilderTest.java
+++ b/commons-rdf-jsonld-java/src/test/java/org/apache/commons/rdf/jsonldjava/JsonLdParserBuilderTest.java
@@ -17,9 +17,9 @@
  */
 package org.apache.commons.rdf.jsonldjava;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -34,7 +34,7 @@ import org.apache.commons.rdf.api.Literal;
 import org.apache.commons.rdf.api.RDFSyntax;
 import org.apache.commons.rdf.jsonldjava.experimental.JsonLdParser;
 import org.apache.commons.rdf.simple.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsonLdParserBuilderTest {
     private static final String TEST_JSONLD = "/test.jsonld";
@@ -74,7 +74,7 @@ public class JsonLdParserBuilderTest {
         final Path path = Files.createTempFile("test", ".jsonld");
         path.toFile().deleteOnExit();
         try (InputStream is = getClass().getResourceAsStream(TEST_JSONLD)) {
-            assertNotNull("Test resource not found: " + TEST_JSONLD, is);
+            assertNotNull(is, "Test resource not found: " + TEST_JSONLD);
             Files.copy(is, path, StandardCopyOption.REPLACE_EXISTING);
         }
         try (final Graph g = factory.createGraph()) {
@@ -87,7 +87,7 @@ public class JsonLdParserBuilderTest {
     public void testParseByStream() throws Exception {
         try (final Graph g = factory.createGraph()) {
             try (InputStream is = getClass().getResourceAsStream(TEST_JSONLD)) {
-                assertNotNull("Test resource not found: " + TEST_JSONLD, is);
+                assertNotNull(is, "Test resource not found: " + TEST_JSONLD);
                 new JsonLdParser().base("http://example.com/base/").contentType(RDFSyntax.JSONLD).source(is).target(g)
                         .parse().get(10, TimeUnit.SECONDS);
             }
@@ -98,7 +98,7 @@ public class JsonLdParserBuilderTest {
     @Test
     public void testParseByUrl() throws Exception {
         final URL url = getClass().getResource(TEST_JSONLD);
-        assertNotNull("Test resource not found: " + TEST_JSONLD, url);
+        assertNotNull(url, "Test resource not found: " + TEST_JSONLD);
         final IRI iri = factory.createIRI(url.toString());
         try (final Graph g = factory.createGraph()) {
             new JsonLdParser().contentType(RDFSyntax.JSONLD).source(iri).target(g).parse().get(10, TimeUnit.SECONDS);

--- a/commons-rdf-jsonld-java/src/test/java/org/apache/commons/rdf/jsonldjava/JsonLdRDFTest.java
+++ b/commons-rdf-jsonld-java/src/test/java/org/apache/commons/rdf/jsonldjava/JsonLdRDFTest.java
@@ -19,8 +19,8 @@ package org.apache.commons.rdf.jsonldjava;
 
 import org.apache.commons.rdf.api.AbstractRDFTest;
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class JsonLdRDFTest extends AbstractRDFTest {
 
@@ -29,7 +29,7 @@ public class JsonLdRDFTest extends AbstractRDFTest {
         return new JsonLdRDF();
     }
 
-    @Ignore("JSONLD-Java does not validate IRIs")
+    @Disabled("JSONLD-Java does not validate IRIs")
     @Test
     @Override
     public void testInvalidIRI() throws Exception {
@@ -37,14 +37,14 @@ public class JsonLdRDFTest extends AbstractRDFTest {
     }
 
     // TODO: Add support for checking for invalid lang/iri/blanknode IDs
-    @Ignore("JSONLD-Java does not validate lang strings")
+    @Disabled("JSONLD-Java does not validate lang strings")
     @Test
     @Override
     public void testInvalidLiteralLang() throws Exception {
         super.testInvalidLiteralLang();
     }
 
-    @Ignore("JSONLD-Java does not validate blanknode identifiers")
+    @Disabled("JSONLD-Java does not validate blanknode identifiers")
     @Test
     @Override
     public void testPossiblyInvalidBlankNode() throws Exception {

--- a/commons-rdf-jsonld-java/src/test/java/org/apache/commons/rdf/jsonldjava/JsonLdServiceLoaderTest.java
+++ b/commons-rdf-jsonld-java/src/test/java/org/apache/commons/rdf/jsonldjava/JsonLdServiceLoaderTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.commons.rdf.jsonldjava;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ServiceLoader;
 
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsonLdServiceLoaderTest {
 

--- a/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/MemoryStoreRDFTest.java
+++ b/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/MemoryStoreRDFTest.java
@@ -19,7 +19,8 @@ package org.apache.commons.rdf.rdf4j;
 
 import org.apache.commons.rdf.api.AbstractRDFTest;
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Assume;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class MemoryStoreRDFTest extends AbstractRDFTest {
 
@@ -29,8 +30,9 @@ public class MemoryStoreRDFTest extends AbstractRDFTest {
     }
 
     @Override
+    @Test
+    @Disabled("RDF4J doesn't check Lang strings")
     public void testInvalidLiteralLang() throws Exception {
-        Assume.assumeTrue("RDF4J doesn't check Lang strings", false);
         super.testInvalidLiteralLang();
     }
 

--- a/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/RDF4JMethodOverloadsTest.java
+++ b/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/RDF4JMethodOverloadsTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.commons.rdf.rdf4j;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RDF4JMethodOverloadsTest {
 

--- a/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/RDF4JServiceLoaderTest.java
+++ b/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/RDF4JServiceLoaderTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.commons.rdf.rdf4j;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ServiceLoader;
 
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RDF4JServiceLoaderTest {
 

--- a/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/RDF4JTest.java
+++ b/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/RDF4JTest.java
@@ -19,7 +19,8 @@ package org.apache.commons.rdf.rdf4j;
 
 import org.apache.commons.rdf.api.AbstractRDFTest;
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Assume;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class RDF4JTest extends AbstractRDFTest {
 
@@ -29,8 +30,9 @@ public class RDF4JTest extends AbstractRDFTest {
     }
 
     @Override
+    @Test
+    @Disabled("RDF4J doesn't check Lang strings")
     public void testInvalidLiteralLang() throws Exception {
-        Assume.assumeTrue("RDF4J doesn't check Lang strings", false);
         super.testInvalidLiteralLang();
     }
 

--- a/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/SimpleDatasetTest.java
+++ b/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/SimpleDatasetTest.java
@@ -17,12 +17,13 @@
  */
 package org.apache.commons.rdf.simple;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 
 import org.apache.commons.rdf.api.AbstractDatasetTest;
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test SimpleRDF with AbstractGraphTest
@@ -36,7 +37,7 @@ public class SimpleDatasetTest extends AbstractDatasetTest {
 
     @Test
     public void testDatasetToString() {
-        Assume.assumeNotNull(aliceName, companyName);
+        assumeTrue(aliceName != null && companyName != null);
         //System.out.println(dataset);
         assertTrue(
                 dataset.toString().contains("<http://example.com/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" <http://example.com/graph1> ."));

--- a/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/SimpleGraphTest.java
+++ b/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/SimpleGraphTest.java
@@ -17,12 +17,12 @@
  */
 package org.apache.commons.rdf.simple;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.apache.commons.rdf.api.AbstractGraphTest;
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test SimpleRDF with AbstractGraphTest
@@ -36,7 +36,7 @@ public class SimpleGraphTest extends AbstractGraphTest {
 
     @Test
     public void testGraphToString() {
-        Assume.assumeNotNull(aliceName, companyName);
+        assumeTrue(aliceName != null && companyName != null);
         // System.out.println(graph);
         assertTrue(
                 graph.toString().contains("<http://example.com/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" ."));

--- a/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/SimpleServiceLoaderTest.java
+++ b/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/SimpleServiceLoaderTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.commons.rdf.simple;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ServiceLoader;
 
 import org.apache.commons.rdf.api.RDF;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SimpleServiceLoaderTest {
 

--- a/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/TestWritingGraph.java
+++ b/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/TestWritingGraph.java
@@ -17,7 +17,7 @@
  */
 package org.apache.commons.rdf.simple;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -31,9 +31,9 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.api.Triple;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test writing graph
@@ -55,7 +55,7 @@ public class TestWritingGraph {
 
     private static RDF factory;
 
-    @BeforeClass
+    @BeforeAll
     public static void createGraph() throws Exception {
         factory = new SimpleRDF();
         graph = factory.createGraph();
@@ -79,7 +79,7 @@ public class TestWritingGraph {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() throws Exception {
         graph.clear();
         graph = null;
@@ -96,7 +96,7 @@ public class TestWritingGraph {
         final IRI predicate = factory.createIRI("pred");
         final long count = graph.stream(subject, predicate, null).unordered().parallel().count();
         // System.out.println("Counted - " + count);
-        assertEquals(count, TRIPLES);
+        assertEquals(TRIPLES, count);
     }
 
     @Test

--- a/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/TypesTest.java
+++ b/commons-rdf-simple/src/test/java/org/apache/commons/rdf/simple/TypesTest.java
@@ -17,11 +17,11 @@
  */
 package org.apache.commons.rdf.simple;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@link org.apache.commons.rdf.simple.Types} enumeration.

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,13 @@
         <commons.scmPubCheckoutDirectory>${project.build.directory}/site-content</commons.scmPubCheckoutDirectory>
         -->
         <commons.javadoc.java.link>https://docs.oracle.com/javase/8/docs/api/</commons.javadoc.java.link>
-        
+
 	    <!--  NOTE: jsonldjava is also used by rdf4j and jena, check the version
 	          is cross-compatible -->
         <jsonldjava.version>0.13.4</jsonldjava.version>
         <rdf4j.version>3.7.7</rdf4j.version>
         <jena.version>3.5.0</jena.version>
-        <!--  NOTE: dexx and xerces versions should match 
+        <!--  NOTE: dexx and xerces versions should match
         the versions marked as <optional> in jena-osgi pom
          -->
         <dexx.collection.version>0.7</dexx.collection.version>
@@ -72,7 +72,7 @@
 
         <!-- Test dependencies -->
         <slf4j.version>1.7.26</slf4j.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.version>5.11.4</junit.version>
         <skipAPICompatCheck>false</skipAPICompatCheck>
         <moditect.skip>true</moditect.skip>
     </properties>
@@ -253,8 +253,8 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
             </dependency>
             <dependency>
@@ -265,14 +265,14 @@
         </dependencies>
     </dependencyManagement>
 
-    <!--  
-    Common dependencies across modules. 
+    <!--
+    Common dependencies across modules.
     Keep this list small and only <scope>test</scope> !
     -->
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -286,7 +286,7 @@
             <artifactId>commons-io</artifactId>
             <version>2.18.0</version>
             <scope>test</scope>
-        </dependency>    
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5.

Migration includes:

* Using JUnit5 annotations
* Using `Assertions` over `Assert`
* Remove `public` modifiers from test classes and methods
* Clean up assertions (switching `expected` and `actual`, simplyifing assertions...)
* Trivial code cleanup

I validated my changes using `mvn verify` and noticed that one test failed before and after my changes, others pass just fine.

```
[ERROR] Failures: 
[ERROR]   DatasetJenaTest>AbstractDatasetTest.testStreamDefaultGraphNameByPattern:704 expected: <null> but was: <<http://example.com/graph1>>
```