### PR TITLE
upgrade rdf4j to 5.1.3 (Tue, Apr 15, 2025)

### DIFF
--- a/commons-rdf-integration-tests/src/test/resources/alice-cached.jsonld
+++ b/commons-rdf-integration-tests/src/test/resources/alice-cached.jsonld
@@ -1,8 +1,8 @@
 { "http://purl.org/dc/terms/license" :
    "Licensed to the Apache Software Foundation (ASF) under one or more\n contributor license agreements.  See the NOTICE file distributed with\n this work for additional information regarding copyright ownership.\n The ASF licenses this file to You under the Apache License, Version 2.0\n (the \"License\"); you may not use this file except in compliance with\n the License.  You may obtain a copy of the License at\n \n http://www.apache.org/licenses/LICENSE-2.0\n \n Unless required by applicable law or agreed to in writing, software\n distributed under the License is distributed on an \"AS IS\" BASIS,\n WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n See the License for the specific language governing permissions and\n limitations under the License.\n",
   
-  "@context": "http://example.com/context",
-  "@id": "ex:Alice",
+  "@context": "https://schema.org/docs/jsonldcontext.jsonld",
+  "@id": "http://example.com/Alice",
   "@type": "Person",
   "name": "Alice W. Land"
 }

--- a/commons-rdf-rdf4j/src/main/java/org/apache/commons/rdf/rdf4j/RDF4J.java
+++ b/commons-rdf-rdf4j/src/main/java/org/apache/commons/rdf/rdf4j/RDF4J.java
@@ -109,7 +109,7 @@ public final class RDF4J implements RDF {
          */
         includeInferred,
         /**
-         * The graph/dataset should handle {@link Repository#initialize()} (if
+         * The graph/dataset should handle {@link Repository#init()} (if
          * needed) and {@link Repository#shutDown()} on {@link Graph#close()} /
          * {@link Dataset#close()}.
          */

--- a/commons-rdf-rdf4j/src/main/java/org/apache/commons/rdf/rdf4j/impl/AbstractRepositoryGraphLike.java
+++ b/commons-rdf-rdf4j/src/main/java/org/apache/commons/rdf/rdf4j/impl/AbstractRepositoryGraphLike.java
@@ -43,7 +43,7 @@ abstract class AbstractRepositoryGraphLike<T extends TripleLike> implements RDF4
         this.includeInferred = includeInferred;
         this.handleInitAndShutdown = handleInitAndShutdown;
         if (handleInitAndShutdown && !repository.isInitialized()) {
-            repository.initialize();
+            repository.init();
         }
         rdf4jTermFactory = new RDF4J(repository.getValueFactory(), salt);
     }

--- a/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/MemoryGraphTest.java
+++ b/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/MemoryGraphTest.java
@@ -56,7 +56,7 @@ public class MemoryGraphTest extends AbstractGraphTest {
         public RDF4JGraph createGraph() {
             final Sail sail = new MemoryStore();
             final Repository repository = new SailRepository(sail);
-            repository.initialize();
+            repository.init();
             return rdf4jFactory.asGraph(repository);
         }
 

--- a/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/NativeStoreGraphTest.java
+++ b/commons-rdf-rdf4j/src/test/java/org/apache/commons/rdf/rdf4j/NativeStoreGraphTest.java
@@ -130,7 +130,7 @@ public class NativeStoreGraphTest extends AbstractGraphTest {
     public void createRepository() throws IOException {
         final Sail sail = new NativeStore(newFolder(tempDir, "junit"));
         repository = new SailRepository(sail);
-        repository.initialize();
+        repository.init();
     }
 
     public synchronized SailRepository getRepository() {

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 	    <!--  NOTE: jsonldjava is also used by rdf4j and jena, check the version
 	          is cross-compatible -->
         <jsonldjava.version>0.13.4</jsonldjava.version>
-        <rdf4j.version>3.7.7</rdf4j.version>
+        <rdf4j.version>4.0.0</rdf4j.version>
         <jena.version>3.5.0</jena.version>
         <!--  NOTE: dexx and xerces versions should match
         the versions marked as <optional> in jena-osgi pom

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 	    <!--  NOTE: jsonldjava is also used by rdf4j and jena, check the version
 	          is cross-compatible -->
         <jsonldjava.version>0.13.4</jsonldjava.version>
-        <rdf4j.version>4.0.0</rdf4j.version>
+        <rdf4j.version>5.1.3</rdf4j.version>
         <jena.version>3.5.0</jena.version>
         <!--  NOTE: dexx and xerces versions should match
         the versions marked as <optional> in jena-osgi pom


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

With this PR commons-rdf is using the newest version (Tue, Apr 15, 2025) of rdf4j.
